### PR TITLE
Fix/remove fallbacks sensiveis prod

### DIFF
--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/config/Producers.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/config/Producers.java
@@ -3,8 +3,8 @@ package br.com.fiap.techchallenge.feedbackplatform.infrastructure.config;
 import java.util.List;
 
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackRepositoryPort;
+import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackUrgenciaClassifier;
 import br.com.fiap.techchallenge.feedbackplatform.application.usecase.CreateFeedbackUseCase;
-import br.com.fiap.techchallenge.feedbackplatform.infrastructure.classifier.FeedbackUrgenciaClassifierAdapter;
 import br.com.fiap.techchallenge.feedbackplatform.infrastructure.notify.EmailSender;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
@@ -15,8 +15,13 @@ public class Producers {
     @Produces
     @ApplicationScoped
     public CreateFeedbackUseCase createFeedbackUseCaseProducer(
-            FeedbackRepositoryPort feedbackRepository, EmailSender emailSender) {
-        return new CreateFeedbackUseCase(feedbackRepository, new FeedbackUrgenciaClassifierAdapter(),
-                List.of((feedback) -> emailSender.send(feedback)));
+            FeedbackRepositoryPort feedbackRepository,
+            FeedbackUrgenciaClassifier urgenciaClassifier,
+            EmailSender emailSender) {
+
+        return new CreateFeedbackUseCase(
+                feedbackRepository,
+                urgenciaClassifier,
+                List.of(emailSender::send));
     }
 }

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSender.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSender.java
@@ -2,6 +2,7 @@ package br.com.fiap.techchallenge.feedbackplatform.infrastructure.notify;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -27,6 +28,7 @@ public class EmailSender implements Notification<Feedback> {
     private static final Logger LOG = LoggerFactory.getLogger(EmailSender.class);
 
     private static final ZoneId ZONE_ID_SP = ZoneId.of("America/Sao_Paulo");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
 
     @Inject
     @ConfigProperty(name = "app.email.connection-string")
@@ -46,26 +48,20 @@ public class EmailSender implements Notification<Feedback> {
 
     @Override
     public void send(Feedback feedback) {
-        EmailClient emailClient = new EmailClientBuilder().connectionString(connectionString).buildClient();
+        EmailClient emailClient = new EmailClientBuilder()
+                .connectionString(connectionString)
+                .buildClient();
 
-        String[] addressesSplitted = adminEmails.split(";");
+        List<EmailAddress> addresses = extrairEmailsAdministradores(adminEmails)
+                .stream()
+                .map(EmailAddress::new)
+                .toList();
 
-        var addresses = Stream.of(addressesSplitted).map(EmailAddress::new).toList();
+        if (addresses.isEmpty()) {
+            throw new IllegalStateException("Nenhum e-mail de administrador configurado em app.admin-emails.");
+        }
 
-        String body = """
-                <html>
-                    <body>
-                        <h1>Feedback crítico recebido</h1>
-                        <p><strong>Descrição:</strong> %s</p>
-                        <p><strong>Urgência:</strong> %s</p>
-                        <p><strong>Data de envio:</strong> %s</p>
-                    </body>
-                </html>
-                """;
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
-        String dataFormatada = feedback.dataCriacao().atZoneSameInstant(ZONE_ID_SP).format(formatter);
-
-        String bodyFormatted = String.format(body, feedback.descricao(), feedback.urgencia(), dataFormatada);
+        String bodyFormatted = montarCorpoEmail(feedback);
 
         EmailMessage emailMessage = new EmailMessage()
                 .setSenderAddress(senderAddress)
@@ -77,5 +73,51 @@ public class EmailSender implements Notification<Feedback> {
         PollResponse<EmailSendResult> result = poller.waitForCompletion(java.time.Duration.ofSeconds(10));
 
         LOG.info("Email sent with message Id: {}", result.getValue().getId());
+    }
+
+    static String montarCorpoEmail(Feedback feedback) {
+        String body = """
+                <html>
+                    <body>
+                        <h1>Feedback crítico recebido</h1>
+                        <p><strong>Descrição:</strong> %s</p>
+                        <p><strong>Urgência:</strong> %s</p>
+                        <p><strong>Data de envio:</strong> %s</p>
+                    </body>
+                </html>
+                """;
+
+        String descricaoSegura = escaparHtml(feedback.descricao());
+        String urgenciaSegura = escaparHtml(feedback.urgencia().name());
+        String dataFormatada = feedback.dataCriacao()
+                .atZoneSameInstant(ZONE_ID_SP)
+                .format(FORMATTER);
+
+        return String.format(body, descricaoSegura, urgenciaSegura, dataFormatada);
+    }
+
+    static List<String> extrairEmailsAdministradores(String emailsConfigurados) {
+        if (emailsConfigurados == null || emailsConfigurados.isBlank()) {
+            return List.of();
+        }
+
+        return Stream.of(emailsConfigurados.split("[;,]"))
+                .map(String::trim)
+                .filter(email -> !email.isBlank())
+                .distinct()
+                .toList();
+    }
+
+    static String escaparHtml(String valor) {
+        if (valor == null) {
+            return "";
+        }
+
+        return valor
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,22 +11,22 @@ quarkus.flyway.migrate-at-start=true
 
 # Database
 quarkus.datasource.db-kind=${FEEDBACK_DB_KIND:postgresql}
-quarkus.datasource.jdbc.url=${FEEDBACK_DB_URL:${kv//FeedBackDBUrl:jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH}}
-quarkus.datasource.username=${FEEDBACK_DB_USER:${kv//FeedbackDBUser:sa}}
-quarkus.datasource.password=${FEEDBACK_DB_PASSWORD:${kv//FeedBackDBPassword:sa}}
+quarkus.datasource.jdbc.url=${FEEDBACK_DB_URL:${kv//FeedBackDBUrl}}
+quarkus.datasource.username=${FEEDBACK_DB_USER:${kv//FeedbackDBUser}}
+quarkus.datasource.password=${FEEDBACK_DB_PASSWORD:${kv//FeedBackDBPassword}}
 
 # Email
-app.email.connection-string=${kv//FeedbackDBEmailConnectionString:}
-app.admin-emails=${kv//FeedbackAdminEmailList:}
-app.email.sender-address=${kv//FeedbackEmailSenderAddress:}
-app.email.subject=${EMAIL_SUBJECT:Feedback de insatisfaÃ§Ã£o recebido - FeedBack Platform}
+app.email.connection-string=${EMAIL_CONNECTION_STRING:${kv//FeedbackDBEmailConnectionString}}
+app.admin-emails=${ADMIN_EMAILS:${kv//FeedbackAdminEmailList}}
+app.email.sender-address=${EMAIL_SENDER_ADDRESS:${kv//FeedbackEmailSenderAddress}}
+app.email.subject=${EMAIL_SUBJECT:Feedback de insatisfação recebido - FeedBack Platform}
 
 # JWT
 mp.jwt.verify.issuer=https://feedback-login.com.br/issuer
-mp.jwt.verify.publickey=${kv//jwt-public-key:mock-key}
-%test.mp.jwt.verify.publickey=mock-key
+mp.jwt.verify.publickey=${JWT_PUBLIC_KEY:${kv//jwt-public-key}}
+
 # ------------------------------------------------------------
-# Perfil DEV - execuÃ§Ã£o local com mvn quarkus:dev
+# Perfil DEV - execução local com mvn quarkus:dev
 # ------------------------------------------------------------
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:feedback_dev;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1
@@ -37,6 +37,8 @@ mp.jwt.verify.publickey=${kv//jwt-public-key:mock-key}
 %dev.app.admin-emails=test@example.com
 %dev.app.email.sender-address=test@example.com
 %dev.app.email.subject=Feedback Dev
+
+%dev.mp.jwt.verify.publickey=mock-key
 
 %dev.quarkus.otel.enabled=false
 %dev.quarkus.otel.sdk.disabled=true

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSenderTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSenderTest.java
@@ -1,0 +1,95 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.notify;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.Feedback;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EmailSenderTest {
+
+    @Test
+    void deveExtrairEmailsSeparadosPorPontoEVirgulaEVirgulaAplicandoTrim() {
+        List<String> emails = EmailSender.extrairEmailsAdministradores(
+                "admin1@example.com; admin2@example.com, admin3@example.com");
+
+        assertEquals(
+                List.of(
+                        "admin1@example.com",
+                        "admin2@example.com",
+                        "admin3@example.com"),
+                emails);
+    }
+
+    @Test
+    void deveIgnorarEmailsVazios() {
+        List<String> emails = EmailSender.extrairEmailsAdministradores(
+                "admin1@example.com; ; , admin2@example.com,, ");
+
+        assertEquals(
+                List.of(
+                        "admin1@example.com",
+                        "admin2@example.com"),
+                emails);
+    }
+
+    @Test
+    void deveRemoverEmailsDuplicados() {
+        List<String> emails = EmailSender.extrairEmailsAdministradores(
+                "admin@example.com; admin@example.com, outro@example.com");
+
+        assertEquals(
+                List.of(
+                        "admin@example.com",
+                        "outro@example.com"),
+                emails);
+    }
+
+    @Test
+    void deveRetornarListaVaziaQuandoEmailsNaoForemConfigurados() {
+        assertEquals(List.of(), EmailSender.extrairEmailsAdministradores(null));
+        assertEquals(List.of(), EmailSender.extrairEmailsAdministradores(""));
+        assertEquals(List.of(), EmailSender.extrairEmailsAdministradores("   "));
+    }
+
+    @Test
+    void deveEscaparConteudoHtml() {
+        String descricao = "<script>alert('x')</script> & \"teste\"";
+
+        String descricaoEscapada = EmailSender.escaparHtml(descricao);
+
+        assertEquals(
+                "&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt; &amp; &quot;teste&quot;",
+                descricaoEscapada);
+    }
+
+    @Test
+    void deveRetornarStringVaziaQuandoValorHtmlForNulo() {
+        assertEquals("", EmailSender.escaparHtml(null));
+    }
+
+    @Test
+    void deveMontarCorpoDoEmailComDescricaoEscapada() {
+        Feedback feedback = new Feedback(
+                UUID.randomUUID(),
+                "<b>Erro crítico</b> & problema no sistema",
+                2,
+                Urgencia.ALTA,
+                OffsetDateTime.parse("2026-05-16T15:30:00Z"));
+
+        String body = EmailSender.montarCorpoEmail(feedback);
+
+        assertFalse(body.contains("<b>Erro crítico</b>"));
+        assertFalse(body.contains("& problema no sistema"));
+
+        assertTrue(body.contains("&lt;b&gt;Erro crítico&lt;/b&gt; &amp; problema no sistema"));
+        assertTrue(body.contains("ALTA"));
+        assertTrue(body.contains("16/05/2026"));
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,34 +1,17 @@
-# application.properties de test
-
-quarkus.http.root-path=api
-
-quarkus.azure.keyvault.secret.endpoint=https://localhost
+# application.properties de teste
 
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:feedback_test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1
 quarkus.datasource.username=sa
 quarkus.datasource.password=sa
 
-quarkus.hibernate-orm.schema-management.strategy=none
-quarkus.flyway.migrate-at-start=true
-
 app.email.connection-string=endpoint=https://localhost;accesskey=mock
 app.admin-emails=test@example.com
 app.email.sender-address=test@example.com
 app.email.subject=Feedback Test
 
-# Evita chamadas reais de observabilidade nos testes
+mp.jwt.verify.issuer=https://feedback-login.com.br/issuer
+mp.jwt.verify.publickey=mock-key
+
 quarkus.otel.enabled=false
 quarkus.otel.sdk.disabled=true
-
-# Evita tentativa de Service Bus real nos testes, se a extensão for adicionada depois
-# quarkus.azure.servicebus.connection-string=
-# quarkus.azure.servicebus.queue-name=
-# quarkus.azure.servicebus.namespace=
-# quarkus.azure.servicebus.devservices.enabled=false
-
-# ------------------------------------------------------------
-# Report Storage
-# ------------------------------------------------------------
-app.reports.storage.connection-string=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
-app.reports.storage.container-name=feedback-reports


### PR DESCRIPTION
Remove fallbacks sensíveis da configuração principal.

Ajustes realizados:
- remove fallback para H2 no perfil principal;
- remove fallback para usuário/senha mockados no perfil principal;
- remove fallback para mock-key no JWT de produção;
- mantém H2, mock-key e e-mail fake apenas no ambiente de teste/desenvolvimento;
- preserva defaults não sensíveis, como app-name, root-path, db-kind=postgresql, subject do e-mail e issuer JWT.