### PR TITLE
Feat/log notificacoes feedback

### DIFF
--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/application/ports/FeedbackNotificationLogRepositoryPort.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/application/ports/FeedbackNotificationLogRepositoryPort.java
@@ -1,0 +1,8 @@
+package br.com.fiap.techchallenge.feedbackplatform.application.ports;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
+
+public interface FeedbackNotificationLogRepositoryPort {
+
+    FeedbackNotificationLog save(FeedbackNotificationLog notificationLog);
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/enums/FeedbackNotificationStatus.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/enums/FeedbackNotificationStatus.java
@@ -1,0 +1,6 @@
+package br.com.fiap.techchallenge.feedbackplatform.domain.enums;
+
+public enum FeedbackNotificationStatus {
+    ENVIADA,
+    FALHA
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/enums/FeedbackNotificationType.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/enums/FeedbackNotificationType.java
@@ -1,0 +1,5 @@
+package br.com.fiap.techchallenge.feedbackplatform.domain.enums;
+
+public enum FeedbackNotificationType {
+    EMAIL
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/Feedback.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/Feedback.java
@@ -35,17 +35,6 @@ public record Feedback(
                 OffsetDateTime.now());
     }
 
-    public Feedback marcarAlertaEnviado(OffsetDateTime dataEnvioAlerta) {
-        Objects.requireNonNull(dataEnvioAlerta, "dataEnvioAlerta é obrigatória");
-
-        return new Feedback(
-                id,
-                descricao,
-                nota,
-                urgencia,
-                dataCriacao);
-    }
-
     private static void validarDescricao(String descricao) {
         if (descricao == null || descricao.isBlank()) {
             throw new IllegalArgumentException("Descrição é obrigatória.");

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackNotificationLog.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackNotificationLog.java
@@ -1,0 +1,71 @@
+package br.com.fiap.techchallenge.feedbackplatform.domain.model;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+
+public record FeedbackNotificationLog(
+        UUID id,
+        UUID feedbackId,
+        FeedbackNotificationType tipo,
+        FeedbackNotificationStatus status,
+        OffsetDateTime dataTentativa,
+        String mensagemErro) {
+
+    private static final int TAMANHO_MAXIMO_MENSAGEM_ERRO = 2000;
+
+    public FeedbackNotificationLog {
+        Objects.requireNonNull(id, "id é obrigatório");
+        Objects.requireNonNull(feedbackId, "feedbackId é obrigatório");
+        Objects.requireNonNull(tipo, "tipo é obrigatório");
+        Objects.requireNonNull(status, "status é obrigatório");
+        Objects.requireNonNull(dataTentativa, "dataTentativa é obrigatória");
+
+        if (FeedbackNotificationStatus.FALHA.equals(status)
+                && (mensagemErro == null || mensagemErro.isBlank())) {
+            throw new IllegalArgumentException("mensagemErro é obrigatória para notificações com falha.");
+        }
+
+        mensagemErro = normalizarMensagemErro(mensagemErro);
+    }
+
+    public static FeedbackNotificationLog enviada(UUID feedbackId, FeedbackNotificationType tipo) {
+        return new FeedbackNotificationLog(
+                UUID.randomUUID(),
+                feedbackId,
+                tipo,
+                FeedbackNotificationStatus.ENVIADA,
+                OffsetDateTime.now(),
+                null);
+    }
+
+    public static FeedbackNotificationLog falha(
+            UUID feedbackId,
+            FeedbackNotificationType tipo,
+            String mensagemErro) {
+        return new FeedbackNotificationLog(
+                UUID.randomUUID(),
+                feedbackId,
+                tipo,
+                FeedbackNotificationStatus.FALHA,
+                OffsetDateTime.now(),
+                mensagemErro);
+    }
+
+    private static String normalizarMensagemErro(String mensagemErro) {
+        if (mensagemErro == null || mensagemErro.isBlank()) {
+            return null;
+        }
+
+        String mensagemNormalizada = mensagemErro.trim();
+
+        if (mensagemNormalizada.length() <= TAMANHO_MAXIMO_MENSAGEM_ERRO) {
+            return mensagemNormalizada;
+        }
+
+        return mensagemNormalizada.substring(0, TAMANHO_MAXIMO_MENSAGEM_ERRO);
+    }
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/config/Producers.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/config/Producers.java
@@ -3,8 +3,8 @@ package br.com.fiap.techchallenge.feedbackplatform.infrastructure.config;
 import java.util.List;
 
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackRepositoryPort;
+import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackUrgenciaClassifier;
 import br.com.fiap.techchallenge.feedbackplatform.application.usecase.CreateFeedbackUseCase;
-import br.com.fiap.techchallenge.feedbackplatform.infrastructure.classifier.FeedbackUrgenciaClassifierAdapter;
 import br.com.fiap.techchallenge.feedbackplatform.infrastructure.notify.EmailSender;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
@@ -15,8 +15,13 @@ public class Producers {
     @Produces
     @ApplicationScoped
     public CreateFeedbackUseCase createFeedbackUseCaseProducer(
-            FeedbackRepositoryPort feedbackRepository, EmailSender emailSender) {
-        return new CreateFeedbackUseCase(feedbackRepository, new FeedbackUrgenciaClassifierAdapter(),
-                List.of((feedback) -> emailSender.send(feedback)));
+            FeedbackRepositoryPort feedbackRepository,
+            FeedbackUrgenciaClassifier urgenciaClassifier,
+            EmailSender emailSender) {
+
+        return new CreateFeedbackUseCase(
+                feedbackRepository,
+                urgenciaClassifier,
+                List.of(emailSender::send));
     }
 }

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSender.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSender.java
@@ -2,6 +2,7 @@ package br.com.fiap.techchallenge.feedbackplatform.infrastructure.notify;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -27,6 +28,7 @@ public class EmailSender implements Notification<Feedback> {
     private static final Logger LOG = LoggerFactory.getLogger(EmailSender.class);
 
     private static final ZoneId ZONE_ID_SP = ZoneId.of("America/Sao_Paulo");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
 
     @Inject
     @ConfigProperty(name = "app.email.connection-string")
@@ -46,26 +48,20 @@ public class EmailSender implements Notification<Feedback> {
 
     @Override
     public void send(Feedback feedback) {
-        EmailClient emailClient = new EmailClientBuilder().connectionString(connectionString).buildClient();
+        EmailClient emailClient = new EmailClientBuilder()
+                .connectionString(connectionString)
+                .buildClient();
 
-        String[] addressesSplitted = adminEmails.split(";");
+        List<EmailAddress> addresses = extrairEmailsAdministradores(adminEmails)
+                .stream()
+                .map(EmailAddress::new)
+                .toList();
 
-        var addresses = Stream.of(addressesSplitted).map(EmailAddress::new).toList();
+        if (addresses.isEmpty()) {
+            throw new IllegalStateException("Nenhum e-mail de administrador configurado em app.admin-emails.");
+        }
 
-        String body = """
-                <html>
-                    <body>
-                        <h1>Feedback crítico recebido</h1>
-                        <p><strong>Descrição:</strong> %s</p>
-                        <p><strong>Urgência:</strong> %s</p>
-                        <p><strong>Data de envio:</strong> %s</p>
-                    </body>
-                </html>
-                """;
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
-        String dataFormatada = feedback.dataCriacao().atZoneSameInstant(ZONE_ID_SP).format(formatter);
-
-        String bodyFormatted = String.format(body, feedback.descricao(), feedback.urgencia(), dataFormatada);
+        String bodyFormatted = montarCorpoEmail(feedback);
 
         EmailMessage emailMessage = new EmailMessage()
                 .setSenderAddress(senderAddress)
@@ -77,5 +73,51 @@ public class EmailSender implements Notification<Feedback> {
         PollResponse<EmailSendResult> result = poller.waitForCompletion(java.time.Duration.ofSeconds(10));
 
         LOG.info("Email sent with message Id: {}", result.getValue().getId());
+    }
+
+    static String montarCorpoEmail(Feedback feedback) {
+        String body = """
+                <html>
+                    <body>
+                        <h1>Feedback crítico recebido</h1>
+                        <p><strong>Descrição:</strong> %s</p>
+                        <p><strong>Urgência:</strong> %s</p>
+                        <p><strong>Data de envio:</strong> %s</p>
+                    </body>
+                </html>
+                """;
+
+        String descricaoSegura = escaparHtml(feedback.descricao());
+        String urgenciaSegura = escaparHtml(feedback.urgencia().name());
+        String dataFormatada = feedback.dataCriacao()
+                .atZoneSameInstant(ZONE_ID_SP)
+                .format(FORMATTER);
+
+        return String.format(body, descricaoSegura, urgenciaSegura, dataFormatada);
+    }
+
+    static List<String> extrairEmailsAdministradores(String emailsConfigurados) {
+        if (emailsConfigurados == null || emailsConfigurados.isBlank()) {
+            return List.of();
+        }
+
+        return Stream.of(emailsConfigurados.split("[;,]"))
+                .map(String::trim)
+                .filter(email -> !email.isBlank())
+                .distinct()
+                .toList();
+    }
+
+    static String escaparHtml(String valor) {
+        if (valor == null) {
+            return "";
+        }
+
+        return valor
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
     }
 }

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/entity/FeedbackNotificationLogEntity.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/entity/FeedbackNotificationLogEntity.java
@@ -1,0 +1,90 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "feedback_notification_log")
+public class FeedbackNotificationLogEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @Column(name = "feedback_id", nullable = false)
+    private UUID feedbackId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo", nullable = false, length = 50)
+    private FeedbackNotificationType tipo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private FeedbackNotificationStatus status;
+
+    @Column(name = "data_tentativa", nullable = false)
+    private OffsetDateTime dataTentativa;
+
+    @Column(name = "mensagem_erro", length = 2000)
+    private String mensagemErro;
+
+    public FeedbackNotificationLogEntity() {
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getFeedbackId() {
+        return feedbackId;
+    }
+
+    public void setFeedbackId(UUID feedbackId) {
+        this.feedbackId = feedbackId;
+    }
+
+    public FeedbackNotificationType getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(FeedbackNotificationType tipo) {
+        this.tipo = tipo;
+    }
+
+    public FeedbackNotificationStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(FeedbackNotificationStatus status) {
+        this.status = status;
+    }
+
+    public OffsetDateTime getDataTentativa() {
+        return dataTentativa;
+    }
+
+    public void setDataTentativa(OffsetDateTime dataTentativa) {
+        this.dataTentativa = dataTentativa;
+    }
+
+    public String getMensagemErro() {
+        return mensagemErro;
+    }
+
+    public void setMensagemErro(String mensagemErro) {
+        this.mensagemErro = mensagemErro;
+    }
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/mapper/FeedbackNotificationLogPersistenceMapper.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/mapper/FeedbackNotificationLogPersistenceMapper.java
@@ -1,0 +1,30 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.mapper;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class FeedbackNotificationLogPersistenceMapper {
+
+    public FeedbackNotificationLogEntity toEntity(FeedbackNotificationLog notificationLog) {
+        FeedbackNotificationLogEntity entity = new FeedbackNotificationLogEntity();
+        entity.setId(notificationLog.id());
+        entity.setFeedbackId(notificationLog.feedbackId());
+        entity.setTipo(notificationLog.tipo());
+        entity.setStatus(notificationLog.status());
+        entity.setDataTentativa(notificationLog.dataTentativa());
+        entity.setMensagemErro(notificationLog.mensagemErro());
+        return entity;
+    }
+
+    public FeedbackNotificationLog toDomain(FeedbackNotificationLogEntity entity) {
+        return new FeedbackNotificationLog(
+                entity.getId(),
+                entity.getFeedbackId(),
+                entity.getTipo(),
+                entity.getStatus(),
+                entity.getDataTentativa(),
+                entity.getMensagemErro());
+    }
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/JpaFeedbackNotificationLogRepositoryAdapter.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/JpaFeedbackNotificationLogRepositoryAdapter.java
@@ -1,0 +1,30 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository;
+
+import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackNotificationLogRepositoryPort;
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.mapper.FeedbackNotificationLogPersistenceMapper;
+import io.micrometer.core.annotation.Timed;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class JpaFeedbackNotificationLogRepositoryAdapter implements FeedbackNotificationLogRepositoryPort {
+
+    private final PanacheFeedbackNotificationLogRepository panacheRepository;
+    private final FeedbackNotificationLogPersistenceMapper mapper;
+
+    public JpaFeedbackNotificationLogRepositoryAdapter(
+            PanacheFeedbackNotificationLogRepository panacheRepository,
+            FeedbackNotificationLogPersistenceMapper mapper) {
+        this.panacheRepository = panacheRepository;
+        this.mapper = mapper;
+    }
+
+    @Timed(value = "feedback.notification.log.repository.save", description = "Tempo de execução da gravação do log de notificação")
+    @Override
+    public FeedbackNotificationLog save(FeedbackNotificationLog notificationLog) {
+        FeedbackNotificationLogEntity entity = mapper.toEntity(notificationLog);
+        panacheRepository.persist(entity);
+        return mapper.toDomain(entity);
+    }
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/PanacheFeedbackNotificationLogRepository.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/PanacheFeedbackNotificationLogRepository.java
@@ -1,0 +1,12 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository;
+
+import java.util.UUID;
+
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PanacheFeedbackNotificationLogRepository
+        implements PanacheRepositoryBase<FeedbackNotificationLogEntity, UUID> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,22 +11,22 @@ quarkus.flyway.migrate-at-start=true
 
 # Database
 quarkus.datasource.db-kind=${FEEDBACK_DB_KIND:postgresql}
-quarkus.datasource.jdbc.url=${FEEDBACK_DB_URL:${kv//FeedBackDBUrl:jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH}}
-quarkus.datasource.username=${FEEDBACK_DB_USER:${kv//FeedbackDBUser:sa}}
-quarkus.datasource.password=${FEEDBACK_DB_PASSWORD:${kv//FeedBackDBPassword:sa}}
+quarkus.datasource.jdbc.url=${FEEDBACK_DB_URL:${kv//FeedBackDBUrl}}
+quarkus.datasource.username=${FEEDBACK_DB_USER:${kv//FeedbackDBUser}}
+quarkus.datasource.password=${FEEDBACK_DB_PASSWORD:${kv//FeedBackDBPassword}}
 
 # Email
-app.email.connection-string=${kv//FeedbackDBEmailConnectionString:}
-app.admin-emails=${kv//FeedbackAdminEmailList:}
-app.email.sender-address=${kv//FeedbackEmailSenderAddress:}
-app.email.subject=${EMAIL_SUBJECT:Feedback de insatisfaÃ§Ã£o recebido - FeedBack Platform}
+app.email.connection-string=${EMAIL_CONNECTION_STRING:${kv//FeedbackDBEmailConnectionString}}
+app.admin-emails=${ADMIN_EMAILS:${kv//FeedbackAdminEmailList}}
+app.email.sender-address=${EMAIL_SENDER_ADDRESS:${kv//FeedbackEmailSenderAddress}}
+app.email.subject=${EMAIL_SUBJECT:Feedback de insatisfação recebido - FeedBack Platform}
 
 # JWT
 mp.jwt.verify.issuer=https://feedback-login.com.br/issuer
-mp.jwt.verify.publickey=${kv//jwt-public-key:mock-key}
-%test.mp.jwt.verify.publickey=mock-key
+mp.jwt.verify.publickey=${JWT_PUBLIC_KEY:${kv//jwt-public-key}}
+
 # ------------------------------------------------------------
-# Perfil DEV - execuÃ§Ã£o local com mvn quarkus:dev
+# Perfil DEV - execução local com mvn quarkus:dev
 # ------------------------------------------------------------
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:feedback_dev;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1
@@ -37,6 +37,8 @@ mp.jwt.verify.publickey=${kv//jwt-public-key:mock-key}
 %dev.app.admin-emails=test@example.com
 %dev.app.email.sender-address=test@example.com
 %dev.app.email.subject=Feedback Dev
+
+%dev.mp.jwt.verify.publickey=mock-key
 
 %dev.quarkus.otel.enabled=false
 %dev.quarkus.otel.sdk.disabled=true

--- a/src/main/resources/db/migration/V2__create_feedback_notification_log_table.sql
+++ b/src/main/resources/db/migration/V2__create_feedback_notification_log_table.sql
@@ -1,0 +1,24 @@
+CREATE TABLE feedback_notification_log (
+                                           id UUID PRIMARY KEY,
+                                           feedback_id UUID NOT NULL,
+                                           tipo VARCHAR(50) NOT NULL,
+                                           status VARCHAR(20) NOT NULL,
+                                           data_tentativa TIMESTAMP WITH TIME ZONE NOT NULL,
+                                           mensagem_erro VARCHAR(2000),
+                                           CONSTRAINT fk_feedback_notification_log_feedback
+                                               FOREIGN KEY (feedback_id) REFERENCES feedback(id),
+                                           CONSTRAINT chk_feedback_notification_type
+                                               CHECK (tipo IN ('EMAIL')),
+                                           CONSTRAINT chk_feedback_notification_status
+                                               CHECK (status IN ('ENVIADA', 'FALHA'))
+);
+
+CREATE INDEX idx_feedback_notification_log_feedback_id
+    ON feedback_notification_log (feedback_id);
+
+CREATE INDEX idx_feedback_notification_log_status
+    ON feedback_notification_log (status);
+
+CREATE INDEX idx_feedback_notification_log_data_tentativa
+    ON feedback_notification_log (data_tentativa);
+

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackNotificationLogTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackNotificationLogTest.java
@@ -1,0 +1,88 @@
+package br.com.fiap.techchallenge.feedbackplatform.domain.model;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FeedbackNotificationLogTest {
+
+    @Test
+    void deveCriarLogDeNotificacaoEnviada() {
+        UUID feedbackId = UUID.randomUUID();
+
+        FeedbackNotificationLog log = FeedbackNotificationLog.enviada(
+                feedbackId,
+                FeedbackNotificationType.EMAIL);
+
+        assertNotNull(log.id());
+        assertEquals(feedbackId, log.feedbackId());
+        assertEquals(FeedbackNotificationType.EMAIL, log.tipo());
+        assertEquals(FeedbackNotificationStatus.ENVIADA, log.status());
+        assertNotNull(log.dataTentativa());
+        assertNull(log.mensagemErro());
+    }
+
+    @Test
+    void deveCriarLogDeNotificacaoComFalha() {
+        UUID feedbackId = UUID.randomUUID();
+
+        FeedbackNotificationLog log = FeedbackNotificationLog.falha(
+                feedbackId,
+                FeedbackNotificationType.EMAIL,
+                "Timeout ao enviar e-mail");
+
+        assertNotNull(log.id());
+        assertEquals(feedbackId, log.feedbackId());
+        assertEquals(FeedbackNotificationType.EMAIL, log.tipo());
+        assertEquals(FeedbackNotificationStatus.FALHA, log.status());
+        assertNotNull(log.dataTentativa());
+        assertEquals("Timeout ao enviar e-mail", log.mensagemErro());
+    }
+
+    @Test
+    void deveFalharQuandoFeedbackIdForNulo() {
+        assertThrows(NullPointerException.class, () ->
+                FeedbackNotificationLog.enviada(null, FeedbackNotificationType.EMAIL));
+    }
+
+    @Test
+    void deveFalharQuandoTipoForNulo() {
+        assertThrows(NullPointerException.class, () ->
+                FeedbackNotificationLog.enviada(UUID.randomUUID(), null));
+    }
+
+    @Test
+    void deveFalharQuandoMensagemErroForVaziaParaFalha() {
+        assertThrows(IllegalArgumentException.class, () ->
+                FeedbackNotificationLog.falha(
+                        UUID.randomUUID(),
+                        FeedbackNotificationType.EMAIL,
+                        "   "));
+    }
+
+    @Test
+    void deveLimitarMensagemErroEmDoisMilCaracteres() {
+        String mensagemLonga = "x".repeat(2500);
+
+        FeedbackNotificationLog log = FeedbackNotificationLog.falha(
+                UUID.randomUUID(),
+                FeedbackNotificationType.EMAIL,
+                mensagemLonga);
+
+        assertEquals(2000, log.mensagemErro().length());
+    }
+
+    @Test
+    void deveRemoverEspacosDaMensagemErro() {
+        FeedbackNotificationLog log = FeedbackNotificationLog.falha(
+                UUID.randomUUID(),
+                FeedbackNotificationType.EMAIL,
+                "   Erro ao enviar e-mail   ");
+
+        assertEquals("Erro ao enviar e-mail", log.mensagemErro());
+    }
+}

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSenderTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSenderTest.java
@@ -1,0 +1,95 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.notify;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.Feedback;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EmailSenderTest {
+
+    @Test
+    void deveExtrairEmailsSeparadosPorPontoEVirgulaEVirgulaAplicandoTrim() {
+        List<String> emails = EmailSender.extrairEmailsAdministradores(
+                "admin1@example.com; admin2@example.com, admin3@example.com");
+
+        assertEquals(
+                List.of(
+                        "admin1@example.com",
+                        "admin2@example.com",
+                        "admin3@example.com"),
+                emails);
+    }
+
+    @Test
+    void deveIgnorarEmailsVazios() {
+        List<String> emails = EmailSender.extrairEmailsAdministradores(
+                "admin1@example.com; ; , admin2@example.com,, ");
+
+        assertEquals(
+                List.of(
+                        "admin1@example.com",
+                        "admin2@example.com"),
+                emails);
+    }
+
+    @Test
+    void deveRemoverEmailsDuplicados() {
+        List<String> emails = EmailSender.extrairEmailsAdministradores(
+                "admin@example.com; admin@example.com, outro@example.com");
+
+        assertEquals(
+                List.of(
+                        "admin@example.com",
+                        "outro@example.com"),
+                emails);
+    }
+
+    @Test
+    void deveRetornarListaVaziaQuandoEmailsNaoForemConfigurados() {
+        assertEquals(List.of(), EmailSender.extrairEmailsAdministradores(null));
+        assertEquals(List.of(), EmailSender.extrairEmailsAdministradores(""));
+        assertEquals(List.of(), EmailSender.extrairEmailsAdministradores("   "));
+    }
+
+    @Test
+    void deveEscaparConteudoHtml() {
+        String descricao = "<script>alert('x')</script> & \"teste\"";
+
+        String descricaoEscapada = EmailSender.escaparHtml(descricao);
+
+        assertEquals(
+                "&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt; &amp; &quot;teste&quot;",
+                descricaoEscapada);
+    }
+
+    @Test
+    void deveRetornarStringVaziaQuandoValorHtmlForNulo() {
+        assertEquals("", EmailSender.escaparHtml(null));
+    }
+
+    @Test
+    void deveMontarCorpoDoEmailComDescricaoEscapada() {
+        Feedback feedback = new Feedback(
+                UUID.randomUUID(),
+                "<b>Erro crítico</b> & problema no sistema",
+                2,
+                Urgencia.ALTA,
+                OffsetDateTime.parse("2026-05-16T15:30:00Z"));
+
+        String body = EmailSender.montarCorpoEmail(feedback);
+
+        assertFalse(body.contains("<b>Erro crítico</b>"));
+        assertFalse(body.contains("& problema no sistema"));
+
+        assertTrue(body.contains("&lt;b&gt;Erro crítico&lt;/b&gt; &amp; problema no sistema"));
+        assertTrue(body.contains("ALTA"));
+        assertTrue(body.contains("16/05/2026"));
+    }
+}

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/mapper/FeedbackNotificationLogPersistenceMapperTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/mapper/FeedbackNotificationLogPersistenceMapperTest.java
@@ -1,0 +1,66 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.mapper;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class FeedbackNotificationLogPersistenceMapperTest {
+
+    private final FeedbackNotificationLogPersistenceMapper mapper = new FeedbackNotificationLogPersistenceMapper();
+
+    @Test
+    void deveConverterDominioParaEntidade() {
+        UUID id = UUID.randomUUID();
+        UUID feedbackId = UUID.randomUUID();
+        OffsetDateTime dataTentativa = OffsetDateTime.now();
+
+        FeedbackNotificationLog notificationLog = new FeedbackNotificationLog(
+                id,
+                feedbackId,
+                FeedbackNotificationType.EMAIL,
+                FeedbackNotificationStatus.FALHA,
+                dataTentativa,
+                "Falha ao enviar e-mail");
+
+        FeedbackNotificationLogEntity entity = mapper.toEntity(notificationLog);
+
+        assertEquals(id, entity.getId());
+        assertEquals(feedbackId, entity.getFeedbackId());
+        assertEquals(FeedbackNotificationType.EMAIL, entity.getTipo());
+        assertEquals(FeedbackNotificationStatus.FALHA, entity.getStatus());
+        assertEquals(dataTentativa, entity.getDataTentativa());
+        assertEquals("Falha ao enviar e-mail", entity.getMensagemErro());
+    }
+
+    @Test
+    void deveConverterEntidadeParaDominio() {
+        UUID id = UUID.randomUUID();
+        UUID feedbackId = UUID.randomUUID();
+        OffsetDateTime dataTentativa = OffsetDateTime.now();
+
+        FeedbackNotificationLogEntity entity = new FeedbackNotificationLogEntity();
+        entity.setId(id);
+        entity.setFeedbackId(feedbackId);
+        entity.setTipo(FeedbackNotificationType.EMAIL);
+        entity.setStatus(FeedbackNotificationStatus.ENVIADA);
+        entity.setDataTentativa(dataTentativa);
+        entity.setMensagemErro(null);
+
+        FeedbackNotificationLog notificationLog = mapper.toDomain(entity);
+
+        assertEquals(id, notificationLog.id());
+        assertEquals(feedbackId, notificationLog.feedbackId());
+        assertEquals(FeedbackNotificationType.EMAIL, notificationLog.tipo());
+        assertEquals(FeedbackNotificationStatus.ENVIADA, notificationLog.status());
+        assertEquals(dataTentativa, notificationLog.dataTentativa());
+        assertNull(notificationLog.mensagemErro());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,34 +1,17 @@
-# application.properties de test
-
-quarkus.http.root-path=api
-
-quarkus.azure.keyvault.secret.endpoint=https://localhost
+# application.properties de teste
 
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:feedback_test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1
 quarkus.datasource.username=sa
 quarkus.datasource.password=sa
 
-quarkus.hibernate-orm.schema-management.strategy=none
-quarkus.flyway.migrate-at-start=true
-
 app.email.connection-string=endpoint=https://localhost;accesskey=mock
 app.admin-emails=test@example.com
 app.email.sender-address=test@example.com
 app.email.subject=Feedback Test
 
-# Evita chamadas reais de observabilidade nos testes
+mp.jwt.verify.issuer=https://feedback-login.com.br/issuer
+mp.jwt.verify.publickey=mock-key
+
 quarkus.otel.enabled=false
 quarkus.otel.sdk.disabled=true
-
-# Evita tentativa de Service Bus real nos testes, se a extensão for adicionada depois
-# quarkus.azure.servicebus.connection-string=
-# quarkus.azure.servicebus.queue-name=
-# quarkus.azure.servicebus.namespace=
-# quarkus.azure.servicebus.devservices.enabled=false
-
-# ------------------------------------------------------------
-# Report Storage
-# ------------------------------------------------------------
-app.reports.storage.connection-string=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
-app.reports.storage.container-name=feedback-reports


### PR DESCRIPTION
Adiciona estrutura para rastreabilidade de notificações de feedback.

Ajustes realizados:
  - cria enums FeedbackNotificationType e FeedbackNotificationStatus;
  - cria o domínio FeedbackNotificationLog;
  - cria porta FeedbackNotificationLogRepositoryPort;
  - cria entidade, mapper e adapter JPA para persistência;
  - adiciona migration V2 para a tabela feedback_notification_log;
  - adiciona testes unitários para o domínio e mapper.

Esta etapa prepara a persistência do histórico de notificações. A integração com o fluxo de envio de e-mail será feita em PR separado, registrando notificações ENVIADA ou FALHA sem quebrar a criação do feedback.