### PR TITLE
Test/complementa cobertura

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Links do projeto
 
-> Atualize os links abaixo conforme o repositório e o vídeo final da entrega.
+> TODO: preencher os links finais antes da entrega.
 
 | Item | Link |
 |---|---|
@@ -48,12 +48,18 @@
 10. [Segurança](#segurança)
 11. [Configuração](#configuração)
 12. [Como executar localmente](#como-executar-localmente)
-13. [Testes](#testes)
-14. [Qualidade técnica](#qualidade-técnica)
-15. [Observabilidade](#observabilidade)
-16. [Roteiro de demonstração](#roteiro-de-demonstração)
-17. [Troubleshooting](#troubleshooting)
-18. [Conclusão](#conclusão)
+13. [Deploy](#deploy)
+14. [Testes](#testes)
+15. [Qualidade técnica](#qualidade-técnica)
+16. [Observabilidade](#observabilidade)
+17. [Roteiro de demonstração](#roteiro-de-demonstração)
+18. [Collections para teste](#collections-para-teste)
+19. [Notas sobre Docker, Azurite e escopo do core](#notas-sobre-docker-azurite-e-escopo-do-core)
+20. [Troubleshooting](#troubleshooting)
+21. [Estrutura de pastas](#estrutura-de-pastas)
+22. [Comandos úteis](#comandos-úteis)
+23. [TODOs finais para entrega](#todos-finais-para-entrega)
+24. [Conclusão](#conclusão)
 
 ---
 
@@ -71,7 +77,7 @@ Além do envio de notificações críticas, o serviço registra o histórico das
 
 ## Contexto da Fase 4
 
-A Fase 4 do Tech Challenge propõe uma solução em nuvem/serverless para apoiar o acompanhamento de feedbacks educacionais, automatizando a identificação de avaliações críticas e a comunicação com responsáveis administrativos.
+A Fase 4 do Tech Challenge propõe uma solução em nuvem/serverless para apoiar o acompanhamento de feedbacks educacionais, automatizando a identificação de avaliações críticas, a comunicação com responsáveis administrativos e a geração de relatórios consolidados.
 
 A plataforma foi organizada em componentes especializados:
 
@@ -81,7 +87,7 @@ A plataforma foi organizada em componentes especializados:
 | `az-func-feedback-core` | Recebimento, classificação, persistência e notificação de feedbacks. |
 | `az-func-feedback-report` | Geração semanal de relatório consolidado e armazenamento em Blob Storage. |
 
-O `az-func-feedback-core` concentra o fluxo operacional das avaliações: recebe a manifestação do aluno, aplica as regras de classificação, salva o registro e mantém rastreabilidade das notificações administrativas.
+O `az-func-feedback-core` concentra o fluxo operacional das avaliações: recebe a manifestação do aluno, aplica as regras de classificação, salva o registro, aciona a notificação de feedbacks críticos e mantém rastreabilidade das tentativas de envio.
 
 ---
 
@@ -137,6 +143,12 @@ flowchart LR
 | Azure Key Vault | Fonte segura para segredos em ambiente cloud. |
 | JWT/RBAC | Autorização baseada em papéis (`ALUNO`, `ADMIN`). |
 | H2 | Banco em memória usado em testes automatizados. |
+
+### Escopo do core
+
+O `az-func-feedback-core` **não gera o relatório semanal** e **não grava arquivos em Blob Storage diretamente**. Essas responsabilidades pertencem ao componente `az-func-feedback-report`.
+
+> TODO: confirmar se alguma dependência ou arquivo auxiliar de Blob Storage permanecerá neste repositório ou será movido para o serviço de relatório/infraestrutura.
 
 ---
 
@@ -290,6 +302,13 @@ O domínio `Feedback` exige:
 | `urgencia` | Obrigatória. |
 | `dataCriacao` | Obrigatória. |
 
+A camada REST também valida o payload recebido pela API:
+
+| Campo | Regra na API |
+|---|---|
+| `descricao` | Obrigatória, não vazia, entre 3 e 2000 caracteres. |
+| `nota` | Obrigatória, entre 0 e 10. |
+
 ### Classificação de urgência
 
 A urgência é calculada com base na nota e em palavras críticas presentes na descrição.
@@ -335,7 +354,7 @@ O `EmailSender` aceita múltiplos destinatários em `app.admin-emails` usando `;
 Exemplo:
 
 ```properties
-ADMIN_EMAILS=admin1@email.com; admin2@email.com, admin3@email.com
+app.admin-emails=admin1@email.com; admin2@email.com, admin3@email.com
 ```
 
 O parsing:
@@ -353,13 +372,15 @@ A descrição do feedback é escapada antes de ser inserida no corpo HTML do e-m
 
 ## Endpoints da API
 
-O projeto usa:
+O projeto está documentado considerando o seguinte root path:
 
 ```properties
 quarkus.http.root-path=api
 ```
 
 Portanto, em execução local, os endpoints ficam sob `/api`.
+
+> TODO: confirmar antes da entrega se `quarkus.http.root-path=api` permanece no `src/main/resources/application.properties`. Caso seja removido, ajustar os exemplos para `/avaliacoes` e `/admin/feedbacks/{feedbackId}/notificacoes`.
 
 ### Tabela de endpoints
 
@@ -446,7 +467,7 @@ Accept: application/json
     "feedbackId": "b3a3d6ba-c234-47b9-af77-ec35ad0bf6fe",
     "tipo": "EMAIL",
     "status": "ENVIADA",
-    "dataTentativa": "2026-05-16T21:26:47.670000-03:00",
+    "dataTentativa": "2026-05-16T21:26:47.670000Z",
     "mensagemErro": null
   }
 ]
@@ -461,11 +482,13 @@ Accept: application/json
     "feedbackId": "b3a3d6ba-c234-47b9-af77-ec35ad0bf6fe",
     "tipo": "EMAIL",
     "status": "FALHA",
-    "dataTentativa": "2026-05-16T21:26:47.670000-03:00",
+    "dataTentativa": "2026-05-16T21:26:47.670000Z",
     "mensagemErro": "Timeout ao enviar e-mail"
   }
 ]
 ```
+
+> Observação: o offset de `dataTentativa` pode variar conforme o ambiente de execução. Em Azure, é comum que horários sejam registrados em UTC.
 
 #### Possíveis respostas
 
@@ -516,6 +539,11 @@ Armazena as avaliações recebidas.
 | `urgencia` | `VARCHAR(20)` | `BAIXA`, `MEDIA`, `ALTA` | Classificação calculada. |
 | `data_criacao` | `TIMESTAMP WITH TIME ZONE` | NOT NULL | Data de criação. |
 
+Índices:
+
+- `idx_feedback_data_criacao`;
+- `idx_feedback_urgencia`.
+
 ### Tabela `feedback_notification_log`
 
 Armazena as tentativas de notificação associadas a feedbacks críticos.
@@ -528,6 +556,12 @@ Armazena as tentativas de notificação associadas a feedbacks críticos.
 | `status` | `VARCHAR(20)` | `ENVIADA`, `FALHA` | Resultado da tentativa. |
 | `data_tentativa` | `TIMESTAMP WITH TIME ZONE` | NOT NULL | Data da tentativa. |
 | `mensagem_erro` | `VARCHAR(2000)` | NULL | Mensagem de erro quando houver falha. |
+
+Índices:
+
+- `idx_feedback_notification_log_feedback_id`;
+- `idx_feedback_notification_log_status`;
+- `idx_feedback_notification_log_data_tentativa`.
 
 ---
 
@@ -548,12 +582,14 @@ O serviço valida:
 - chave pública configurada;
 - roles presentes no token.
 
-Exemplo de configuração:
+Exemplo conceitual de configuração:
 
 ```properties
 mp.jwt.verify.issuer=https://feedback-login.com.br/issuer
-mp.jwt.verify.publickey=${JWT_PUBLIC_KEY:${kv//jwt-public-key}}
+mp.jwt.verify.publickey=<chave-publica-ou-referencia-segura>
 ```
+
+> TODO: substituir o exemplo acima pelo nome real do secret ou pela configuração definitiva usada no Azure/Key Vault.
 
 ### Separação de responsabilidade
 
@@ -571,20 +607,40 @@ O arquivo principal fica em:
 src/main/resources/application.properties
 ```
 
-### Variáveis principais
+### Propriedades e origens esperadas
 
-| Variável | Descrição |
+O projeto usa propriedades do Quarkus, variáveis de ambiente e Azure Key Vault para externalizar configurações sensíveis.
+
+| Propriedade da aplicação | Origem esperada | Descrição |
+|---|---|---|
+| `quarkus.azure.keyvault.secret.endpoint` | `QUARKUS_AZURE_KEYVAULT_SECRET_ENDPOINT` | Endpoint do Azure Key Vault. |
+| `quarkus.http.root-path` | `application.properties` | Prefixo base da API. Valor esperado: `api`. |
+| `quarkus.datasource.db-kind` | `QUARKUS_DB_KIND` ou valor configurado no projeto | Tipo do banco. Em produção: PostgreSQL. |
+| `quarkus.datasource.jdbc.url` | Key Vault / variável de ambiente | URL JDBC do PostgreSQL. |
+| `quarkus.datasource.username` | Key Vault / variável de ambiente | Usuário do banco. |
+| `quarkus.datasource.password` | Key Vault / variável de ambiente | Senha do banco. |
+| `app.email.connection-string` | Key Vault / variável de ambiente | Connection string do Azure Communication Email. |
+| `app.admin-emails` | Key Vault / variável de ambiente | Lista de e-mails administrativos. |
+| `app.email.sender-address` | Key Vault / variável de ambiente | Endereço remetente autorizado no Azure Communication Email. |
+| `app.email.subject` | `EMAIL_SUBJECT` ou valor padrão | Assunto do e-mail de alerta. |
+| `mp.jwt.verify.issuer` | configuração da aplicação | Emissor esperado do token JWT. |
+| `mp.jwt.verify.publickey` | Key Vault / variável / arquivo seguro | Chave pública para validação do JWT. |
+
+> TODO: confirmar e documentar os nomes finais dos secrets usados no Azure Key Vault.
+
+### Sugestão de nomes de secrets
+
+Abaixo estão nomes esperados/sugeridos para os secrets, a confirmar conforme o ambiente final:
+
+| Secret | Descrição |
 |---|---|
-| `QUARKUS_AZURE_KEYVAULT_SECRET_ENDPOINT` | Endpoint do Azure Key Vault. |
-| `FEEDBACK_DB_KIND` | Tipo do banco, normalmente `postgresql`. |
-| `FEEDBACK_DB_URL` | URL JDBC do banco. |
-| `FEEDBACK_DB_USER` | Usuário do banco. |
-| `FEEDBACK_DB_PASSWORD` | Senha do banco. |
-| `EMAIL_CONNECTION_STRING` | Connection string do Azure Communication Email. |
-| `ADMIN_EMAILS` | Lista de e-mails dos administradores. |
-| `EMAIL_SENDER_ADDRESS` | Endereço remetente autorizado no Azure Communication Email. |
-| `EMAIL_SUBJECT` | Assunto do e-mail. |
-| `JWT_PUBLIC_KEY` | Chave pública para validação de JWT. |
+| `FeedBackDBUrl` | URL JDBC do PostgreSQL. |
+| `FeedbackDBUser` | Usuário do banco. |
+| `FeedBackDBPassword` | Senha do banco. |
+| `FeedbackDBEmailConnectionString` | Connection string do Azure Communication Email. |
+| `FeedbackAdminEmailList` | Lista de e-mails administrativos. |
+| `FeedbackEmailSenderAddress` | E-mail remetente autorizado. |
+| `jwt-public-key` | Chave pública para validação dos tokens. TODO: confirmar nome real. |
 
 ### Configuração sensível
 
@@ -592,21 +648,27 @@ Valores sensíveis não devem ser versionados no Git.
 
 Em produção, banco, e-mail e chave pública JWT devem vir de:
 
-1. variáveis de ambiente; ou
+1. variáveis de ambiente da Function App; ou
 2. Azure Key Vault.
+
+Em testes automatizados, o projeto usa H2 e valores mockados para e-mail/JWT.
 
 ### Perfil de teste
 
-Os testes usam H2 em memória e valores mockados para e-mail/JWT.
-
-Exemplo conceitual:
+Exemplo conceitual de configuração de teste:
 
 ```properties
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:feedback_test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+
 app.email.connection-string=endpoint=https://localhost;accesskey=mock
 app.admin-emails=test@example.com
 app.email.sender-address=test@example.com
+app.email.subject=Feedback Test
+
+mp.jwt.verify.issuer=https://feedback-login.com.br/issuer
 mp.jwt.verify.publickey=mock-key
 ```
 
@@ -646,9 +708,11 @@ mp.jwt.verify.publickey=mock-key
 ### Clonar o repositório
 
 ```powershell
-git clone https://github.com/KervinCandido/az-func-feedback-core.git
+git clone TODO
 cd az-func-feedback-core
 ```
+
+> TODO: substituir `TODO` pela URL real do repositório.
 
 ### Rodar em modo Quarkus dev
 
@@ -668,6 +732,8 @@ Exemplo:
 http://localhost:8080/api/avaliacoes
 ```
 
+> TODO: confirmar se a execução local em `quarkus:dev` será demonstrada com H2, PostgreSQL local ou banco cloud.
+
 ### Rodar como Azure Function local
 
 Empacote o projeto:
@@ -682,6 +748,60 @@ Depois, acesse o diretório gerado:
 cd target\azure-functions\func-feedback-core
 func host start
 ```
+
+> TODO: confirmar se o comando `func host start` será executado na porta padrão ou com porta customizada no roteiro de demonstração.
+
+---
+
+## Deploy
+
+O projeto é empacotado como **Azure Function HTTP** por meio do **Azure Functions Maven Plugin**.
+
+### Build para deploy
+
+```powershell
+mvn clean package
+```
+
+Após o build, os artefatos da Function são gerados em:
+
+```text
+target/azure-functions/func-feedback-core
+```
+
+### Configurações necessárias no Azure
+
+A Function App precisa ter acesso às configurações de banco, JWT, e-mail e Key Vault por meio de **App Settings** e/ou **Azure Key Vault**.
+
+Configurações esperadas:
+
+- endpoint do Azure Key Vault;
+- URL JDBC do PostgreSQL;
+- usuário e senha do banco;
+- connection string do Azure Communication Email;
+- e-mail remetente autorizado;
+- lista de e-mails administrativos;
+- issuer JWT;
+- chave pública JWT.
+
+### Deploy automatizado
+
+O deploy pode ser realizado via GitHub Actions, executando o build Maven e publicando o pacote gerado para a Function App `func-feedback-core`.
+
+> TODO: inserir o nome definitivo da Function App, o nome do workflow e os secrets configurados no GitHub Actions.
+
+### Checklist mínimo de deploy
+
+- [ ] Function App criada no Azure.
+- [ ] App Settings configurados.
+- [ ] Key Vault configurado.
+- [ ] Permissão da Function App para ler secrets do Key Vault.
+- [ ] Banco PostgreSQL acessível pela Function App.
+- [ ] Azure Communication Email configurado com remetente autorizado.
+- [ ] Chave pública JWT configurada.
+- [ ] GitHub Actions configurado para deploy automatizado.
+- [ ] Teste do endpoint `/api/avaliacoes` em ambiente cloud.
+- [ ] Teste do endpoint `/api/admin/feedbacks/{feedbackId}/notificacoes` em ambiente cloud.
 
 ---
 
@@ -727,6 +847,8 @@ Skipped: 0
 BUILD SUCCESS
 ```
 
+> TODO: atualizar este número caso novos testes sejam adicionados antes da entrega.
+
 ---
 
 ## Qualidade técnica
@@ -759,14 +881,14 @@ A criação do feedback prioriza o registro da avaliação como dado principal d
 Receber feedback → Classificar → Persistir → Notificar se crítico → Registrar tentativa
 ```
 
-Esse desenho garante rastreabilidade do fluxo sem acoplar o resultado da avaliação à disponibilidade momentânea do provedor de e-mail.
+Esse desenho garante rastreabilidade do fluxo sem impedir o recebimento da avaliação caso ocorra uma falha momentânea no provedor de e-mail ou no registro do log de notificação.
 
 ### Segurança
 
 - endpoints protegidos por role;
 - JWT validado por issuer e chave pública;
-- segredos externos via variáveis/Key Vault;
-- configuração principal sem fallbacks sensíveis;
+- valores sensíveis externalizados via variáveis de ambiente ou Azure Key Vault;
+- perfis de teste usando H2 e valores mockados;
 - escape de conteúdo dinâmico no HTML do e-mail.
 
 ### Testabilidade
@@ -774,6 +896,7 @@ Esse desenho garante rastreabilidade do fluxo sem acoplar o resultado da avalia�
 O projeto cobre:
 
 - validações do domínio `Feedback`;
+- validações do domínio `FeedbackNotificationLog`;
 - classificação de urgência;
 - criação do feedback;
 - envio de notificações;
@@ -789,17 +912,26 @@ O projeto cobre:
 
 O projeto possui integração com Micrometer/OpenTelemetry.
 
-Há instrumentação com `@Timed` em operações de repositório, como:
+Há instrumentação com `@Counted` e `@Timed` em pontos relevantes do fluxo.
 
-- salvamento de feedback;
-- salvamento de log de notificação;
-- busca de logs por `feedbackId`.
+Métricas instrumentadas no código:
+
+- `criacoes.avaliacoes`;
+- `criacao.avaliacao.time`;
+- `feedback.repository.save`;
+- `feedback.repository.findById`;
+- `feedback.notification.log.repository.save`;
+- `feedback.notification.log.repository.findByFeedbackId`.
 
 O prefixo padrão das métricas é:
 
 ```properties
 feedback.metrics.prefix=feedback.core.
 ```
+
+A exportação para Azure/Application Insights depende das configurações da Function App e do ambiente de execução.
+
+> TODO: documentar a configuração final de Application Insights/OpenTelemetry usada no ambiente cloud.
 
 ---
 
@@ -822,6 +954,7 @@ POST /api/avaliacoes
 ```
 
 3. Verificar response com `urgencia = BAIXA`.
+4. Explicar que feedbacks `BAIXA` não geram notificação administrativa.
 
 ### Cenário 2 — Avaliação crítica por nota
 
@@ -896,6 +1029,22 @@ Sugestão de cenários:
 8. Validar 401 sem token.
 9. Validar 403 com role incorreta.
 
+> TODO: adicionar a collection real ao repositório ou remover esta seção caso a equipe opte por demonstrar apenas via cURL/PowerShell/Postman local.
+
+---
+
+## Notas sobre Docker, Azurite e escopo do core
+
+O deploy principal deste serviço é via **Azure Functions Maven Plugin**, não via imagem Docker.
+
+Os Dockerfiles gerados pelo Quarkus estão em `src/main/docker`, mas devem ser tratados como artefatos auxiliares. Como o projeto usa Java 25, qualquer execução via Docker JVM deve garantir runtime compatível com Java 25.
+
+> TODO: atualizar/remover Dockerfiles que usem runtime Java 21 caso a equipe decida manter execução via Docker.
+
+Caso exista `docker-compose.yml` com Azurite neste repositório, ele deve ser interpretado como recurso auxiliar de desenvolvimento. O fluxo principal do `az-func-feedback-core` não utiliza Blob Storage diretamente; o Blob Storage pertence ao componente de relatório.
+
+> TODO: decidir se o `docker-compose.yml` com Azurite permanece neste repositório, migra para `az-func-feedback-report` ou fica em um repositório/pasta de infraestrutura.
+
 ---
 
 ## Troubleshooting
@@ -915,6 +1064,8 @@ Verifique os secrets do repositório:
 - `AZURE_TENANT_ID`;
 - `AZURE_SUBSCRIPTION_ID`;
 - `AZURE_CLIENT_SECRET`, se estiver usando Service Principal com secret.
+
+> TODO: ajustar esta seção conforme o modelo real de autenticação usado no workflow.
 
 ### Testes falhando por FK entre `feedback_notification_log` e `feedback`
 
@@ -1020,6 +1171,24 @@ git checkout -b docs/atualiza-readme-core
 
 ---
 
+## TODOs finais para entrega
+
+Antes da entrega final, revisar:
+
+- [ ] Preencher links reais dos repositórios.
+- [ ] Inserir link do vídeo de apresentação.
+- [ ] Inserir ou remover referência à collection Postman/Insomnia.
+- [ ] Confirmar `quarkus.http.root-path=api`.
+- [ ] Confirmar nomes reais dos secrets no Azure Key Vault.
+- [ ] Confirmar configuração real de JWT no core.
+- [ ] Documentar workflow real de deploy no GitHub Actions.
+- [ ] Documentar configuração final de observabilidade/Application Insights.
+- [ ] Confirmar se `docker-compose.yml` com Azurite permanece no core.
+- [ ] Confirmar se dependências relacionadas a Blob Storage permanecem no core ou migram para o report.
+- [ ] Atualizar número de testes caso a suíte mude.
+
+---
+
 ## Conclusão
 
 O `az-func-feedback-core` entrega o fluxo principal de feedbacks da Fase 4 com foco em simplicidade, segurança, rastreabilidade e aderência a uma arquitetura em camadas.
@@ -1028,4 +1197,4 @@ A solução permite que alunos enviem avaliações, classifica automaticamente a
 
 A consulta administrativa dos logs torna o comportamento demonstrável e facilita auditoria técnica da solução.
 
-Este README é uma documentação viva. Em caso de evolução da API ou dos componentes Azure, recomenda-se atualizá-lo junto com o código.
+Este README é uma documentação viva. Em caso de evolução da API, das configurações ou dos componentes Azure, recomenda-se atualizá-lo junto com o código.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ flowchart LR
     Core -->|Feedback ALTA| Email[Azure Communication Email]
     Core -->|Registra tentativa| DB
 
-    Admin[Administrador] -->|GET /api/admin/feedbacks/{id}/notificacoes| Core
+    Admin[Administrador] -->|GET /api/admin/feedbacks/id/notificacoes| Core
 
     Report[az-func-feedback-report] -->|Consulta dados consolidados| DB
     Report -->|Gera relatório semanal| Blob[Azure Blob Storage]

--- a/README.md
+++ b/README.md
@@ -1,65 +1,1031 @@
-# feedback-platform-api
+# az-func-feedback-core — Tech Challenge FIAP Fase 4
 
-This project uses Quarkus, the Supersonic Subatomic Java Framework.
+[![Java](https://img.shields.io/badge/Java-25-blue)](#tecnologias-utilizadas)
+[![Quarkus](https://img.shields.io/badge/Quarkus-3.34.6-purple)](#tecnologias-utilizadas)
+[![Azure Functions](https://img.shields.io/badge/Azure%20Functions-HTTP%20Trigger-0078D4)](#arquitetura-da-solução)
+[![Database](https://img.shields.io/badge/Database-PostgreSQL-336791)](#modelo-de-dados)
+[![Tests](https://img.shields.io/badge/Tests-55%20passing-brightgreen)](#testes)
 
-If you want to learn more about Quarkus, please visit its website: <https://quarkus.io/>.
+## Projeto
 
-## Running the application in dev mode
+**Tech Challenge FIAP — Fase 4**  
+**Curso:** Pós-Graduação em Arquitetura e Desenvolvimento em Java  
+**Serviço:** `az-func-feedback-core`  
+**Tema:** Plataforma serverless para recebimento, classificação, persistência e notificação de feedbacks educacionais.
 
-You can run your application in dev mode that enables live coding using:
+## Equipe
 
-```shell script
-./mvnw quarkus:dev
+| Nome | RM | E-mail |
+|---|---:|---|
+| Alexandre Belisário Duarte Leite de Andrade | RM367163 | alexbdla@gmail.com |
+| Kervin Sama Candido da Silva | RM367345 | kervincandido@gmail.com |
+
+## Links do projeto
+
+> Atualize os links abaixo conforme o repositório e o vídeo final da entrega.
+
+| Item | Link |
+|---|---|
+| Repositório `az-func-feedback-login` | TODO |
+| Repositório `az-func-feedback-core` | TODO |
+| Repositório `az-func-feedback-report` | TODO |
+| Vídeo de apresentação | TODO |
+| Collection Postman/Insomnia | TODO |
+
+---
+
+## Sumário
+
+1. [Visão geral](#visão-geral)
+2. [Contexto da Fase 4](#contexto-da-fase-4)
+3. [Responsabilidades do core](#responsabilidades-do-core)
+4. [Arquitetura da solução](#arquitetura-da-solução)
+5. [Arquitetura interna do serviço](#arquitetura-interna-do-serviço)
+6. [Fluxos operacionais](#fluxos-operacionais)
+7. [Regras de negócio](#regras-de-negócio)
+8. [Endpoints da API](#endpoints-da-api)
+9. [Modelo de dados](#modelo-de-dados)
+10. [Segurança](#segurança)
+11. [Configuração](#configuração)
+12. [Como executar localmente](#como-executar-localmente)
+13. [Testes](#testes)
+14. [Qualidade técnica](#qualidade-técnica)
+15. [Observabilidade](#observabilidade)
+16. [Roteiro de demonstração](#roteiro-de-demonstração)
+17. [Troubleshooting](#troubleshooting)
+18. [Conclusão](#conclusão)
+
+---
+
+## Visão geral
+
+O `az-func-feedback-core` é o componente responsável pelo fluxo central de avaliações da plataforma de feedbacks da Fase 4 do Tech Challenge.
+
+Ele recebe feedbacks enviados por alunos, valida os dados da requisição, classifica automaticamente a urgência, persiste a avaliação no banco de dados e aciona notificações administrativas quando o conteúdo indica um problema crítico.
+
+A solução foi implementada com **Quarkus**, empacotada para execução como **Azure Function HTTP**, integrada com **PostgreSQL**, **Flyway**, **JWT/RBAC**, **Azure Key Vault** e **Azure Communication Email**.
+
+Além do envio de notificações críticas, o serviço registra o histórico das tentativas de notificação, permitindo rastreabilidade operacional e consulta administrativa posterior.
+
+---
+
+## Contexto da Fase 4
+
+A Fase 4 do Tech Challenge propõe uma solução em nuvem/serverless para apoiar o acompanhamento de feedbacks educacionais, automatizando a identificação de avaliações críticas e a comunicação com responsáveis administrativos.
+
+A plataforma foi organizada em componentes especializados:
+
+| Componente | Responsabilidade |
+|---|---|
+| `az-func-feedback-login` | Autenticação e geração de JWT. |
+| `az-func-feedback-core` | Recebimento, classificação, persistência e notificação de feedbacks. |
+| `az-func-feedback-report` | Geração semanal de relatório consolidado e armazenamento em Blob Storage. |
+
+O `az-func-feedback-core` concentra o fluxo operacional das avaliações: recebe a manifestação do aluno, aplica as regras de classificação, salva o registro e mantém rastreabilidade das notificações administrativas.
+
+---
+
+## Responsabilidades do core
+
+O `az-func-feedback-core` é responsável por:
+
+- receber avaliações de alunos;
+- validar campos obrigatórios e limites de nota;
+- classificar feedbacks em `BAIXA`, `MEDIA` ou `ALTA`;
+- persistir feedbacks no banco de dados;
+- notificar administradores quando a urgência for `ALTA`;
+- proteger o endpoint principal com role `ALUNO`;
+- registrar logs das tentativas de notificação;
+- permitir consulta administrativa dos logs por role `ADMIN`;
+- manter testes automatizados cobrindo domínio, casos de uso, classificação, REST, notificação e persistência.
+
+A autenticação e a emissão dos tokens JWT são realizadas pelo componente `az-func-feedback-login`.
+
+---
+
+## Arquitetura da solução
+
+### Visão macro
+
+```mermaid
+flowchart LR
+    Aluno[Aluno] -->|Autenticação| Login[az-func-feedback-login]
+    Login -->|JWT| Aluno
+
+    Aluno -->|POST /api/avaliacoes| Core[az-func-feedback-core]
+
+    Core -->|Valida e classifica| Core
+    Core -->|Persiste feedback| DB[(PostgreSQL)]
+    Core -->|Feedback ALTA| Email[Azure Communication Email]
+    Core -->|Registra tentativa| DB
+
+    Admin[Administrador] -->|GET /api/admin/feedbacks/{id}/notificacoes| Core
+
+    Report[az-func-feedback-report] -->|Consulta dados consolidados| DB
+    Report -->|Gera relatório semanal| Blob[Azure Blob Storage]
 ```
 
-> **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at <http://localhost:8080/q/dev/>.
+### Componentes
 
-## Packaging and running the application
+| Componente | Papel |
+|---|---|
+| Azure Function HTTP | Entrada serverless do serviço core. |
+| Quarkus | Framework de aplicação, REST, CDI, validação, segurança e build. |
+| PostgreSQL | Banco principal para feedbacks e logs de notificação. |
+| Flyway | Controle versionado de schema. |
+| Azure Communication Email | Envio de e-mails para administradores. |
+| Azure Key Vault | Fonte segura para segredos em ambiente cloud. |
+| JWT/RBAC | Autorização baseada em papéis (`ALUNO`, `ADMIN`). |
+| H2 | Banco em memória usado em testes automatizados. |
 
-The application can be packaged using:
+---
 
-```shell script
-./mvnw package
+## Arquitetura interna do serviço
+
+O core foi estruturado seguindo princípios de **Clean Architecture / Ports and Adapters**, separando domínio, casos de uso, portas e adaptadores de infraestrutura.
+
+```mermaid
+flowchart TB
+    subgraph Infraestrutura
+        REST[AvaliacaoResource / AdminFeedbackNotificationLogResource]
+        JPA[JPA/Panache Adapters]
+        EMAIL[EmailSender]
+        CLASSIFIER[FeedbackUrgenciaClassifierAdapter]
+        CONFIG[Producers / CDI]
+    end
+
+    subgraph Aplicacao
+        UC1[CreateFeedbackUseCase]
+        UC2[ListFeedbackNotificationLogsUseCase]
+        PORT_REPO[FeedbackRepositoryPort]
+        PORT_LOG[FeedbackNotificationLogRepositoryPort]
+        PORT_CLASSIFIER[FeedbackUrgenciaClassifier]
+        PORT_NOTIFICATION[Notification]
+    end
+
+    subgraph Dominio
+        FEEDBACK[Feedback]
+        LOG[FeedbackNotificationLog]
+        URGENCIA[Urgencia]
+        LOG_STATUS[FeedbackNotificationStatus]
+        LOG_TYPE[FeedbackNotificationType]
+    end
+
+    REST --> UC1
+    REST --> UC2
+
+    UC1 --> FEEDBACK
+    UC1 --> PORT_REPO
+    UC1 --> PORT_CLASSIFIER
+    UC1 --> PORT_NOTIFICATION
+    UC1 --> PORT_LOG
+
+    UC2 --> PORT_LOG
+
+    PORT_REPO --> JPA
+    PORT_LOG --> JPA
+    PORT_CLASSIFIER --> CLASSIFIER
+    PORT_NOTIFICATION --> EMAIL
+
+    JPA --> DB[(PostgreSQL/H2)]
 ```
 
-It produces the `quarkus-run.jar` file in the `target/quarkus-app/` directory.
-Be aware that it’s not an _über-jar_ as the dependencies are copied into the `target/quarkus-app/lib/` directory.
+### Camadas
 
-The application is now runnable using `java -jar target/quarkus-app/quarkus-run.jar`.
+| Camada | Responsabilidade | Exemplos |
+|---|---|---|
+| `domain` | Modelo de negócio e invariantes. | `Feedback`, `FeedbackNotificationLog`, `Urgencia`. |
+| `application` | Casos de uso, DTOs e portas. | `CreateFeedbackUseCase`, `ListFeedbackNotificationLogsUseCase`. |
+| `infrastructure` | REST, JPA, e-mail, classificação, CDI. | `AvaliacaoResource`, `EmailSender`, repositories Panache. |
+| `resources` | Configuração e migrations. | `application.properties`, `db/migration`. |
+| `test` | Testes unitários e de integração. | `AvaliacaoResourceTest`, `CreateFeedbackUseCaseTest`. |
 
-If you want to build an _über-jar_, execute the following command:
+---
 
-```shell script
-./mvnw package -Dquarkus.package.jar.type=uber-jar
+## Fluxos operacionais
+
+### 1. Fluxo de criação de avaliação
+
+```mermaid
+sequenceDiagram
+    actor Aluno
+    participant API as az-func-feedback-core
+    participant UC as CreateFeedbackUseCase
+    participant Classifier as FeedbackUrgenciaClassifier
+    participant DB as PostgreSQL
+
+    Aluno->>API: POST /api/avaliacoes
+    API->>API: Valida JWT e role ALUNO
+    API->>API: Valida descricao e nota
+    API->>UC: execute(CreateFeedbackCommand)
+    UC->>Classifier: classificar(descricao, nota)
+    Classifier-->>UC: Urgencia
+    UC->>DB: Salva feedback
+    UC-->>API: FeedbackCreatedResult
+    API-->>Aluno: 201 Created
 ```
 
-The application, packaged as an _über-jar_, is now runnable using `java -jar target/*-runner.jar`.
+### 2. Fluxo de notificação crítica
 
-## Creating a native executable
+```mermaid
+sequenceDiagram
+    participant UC as CreateFeedbackUseCase
+    participant Email as EmailSender
+    participant LogRepo as FeedbackNotificationLogRepository
+    participant DB as PostgreSQL
 
-You can create a native executable using:
+    UC->>UC: Verifica feedback.isUrgente()
 
-```shell script
-./mvnw package -Dnative
+    alt Urgência ALTA
+        UC->>Email: send(feedback)
+
+        alt Envio com sucesso
+            UC->>LogRepo: save(ENVIADA)
+            LogRepo->>DB: INSERT feedback_notification_log
+        else Falha no envio
+            UC->>UC: Registra ocorrência no log da aplicação
+            UC->>LogRepo: save(FALHA, mensagemErro)
+            LogRepo->>DB: INSERT feedback_notification_log
+            UC->>UC: Preserva o feedback salvo
+        end
+    else Urgência MEDIA ou BAIXA
+        UC->>UC: Não envia notificação
+    end
 ```
 
-Or, if you don't have GraalVM installed, you can run the native executable build in a container using:
+### 3. Fluxo de consulta administrativa dos logs
 
-```shell script
-./mvnw package -Dnative -Dquarkus.native.container-build=true
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant API as AdminFeedbackNotificationLogResource
+    participant UC as ListFeedbackNotificationLogsUseCase
+    participant Repo as FeedbackNotificationLogRepository
+    participant DB as PostgreSQL
+
+    Admin->>API: GET /api/admin/feedbacks/{feedbackId}/notificacoes
+    API->>API: Valida JWT e role ADMIN
+    API->>UC: execute(feedbackId)
+    UC->>Repo: findByFeedbackId(feedbackId)
+    Repo->>DB: SELECT logs ORDER BY data_tentativa DESC
+    DB-->>Repo: Logs
+    Repo-->>UC: Lista de domínio
+    UC-->>API: Lista de results
+    API-->>Admin: 200 OK
 ```
 
-You can then execute your native executable with: `./target/feedback-platform-api-0.1.0-SNAPSHOT-runner`
+---
 
-If you want to learn more about building native executables, please consult <https://quarkus.io/guides/maven-tooling>.
+## Regras de negócio
 
-## Related Guides
+### Validação do feedback
 
-- REST ([guide](https://quarkus.io/guides/rest)): A Jakarta REST implementation utilizing build time processing and Vert.x. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.
-- Flyway ([guide](https://quarkus.io/guides/flyway)): Handle your database schema migrations
-- Hibernate Validator ([guide](https://quarkus.io/guides/validation)): Validate object properties (field, getter) and method parameters for your beans (REST, CDI, Jakarta Persistence)
-- SmallRye OpenAPI ([guide](https://quarkus.io/guides/openapi-swaggerui)): Document your REST APIs with OpenAPI - comes with Swagger UI
-- REST Jackson ([guide](https://quarkus.io/guides/rest#json-serialisation)): Jackson serialization support for Quarkus REST. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it
-- Hibernate ORM with Panache ([guide](https://quarkus.io/guides/hibernate-orm-panache)): Simplify your persistence code for Hibernate ORM via the active record or the repository pattern
-- SmallRye Health ([guide](https://quarkus.io/guides/smallrye-health)): Monitor service health
-- JDBC Driver - PostgreSQL ([guide](https://quarkus.io/guides/datasource)): Connect to the PostgreSQL database via JDBC
+O domínio `Feedback` exige:
+
+| Campo | Regra |
+|---|---|
+| `id` | Obrigatório. |
+| `descricao` | Obrigatória e não pode ser vazia. |
+| `nota` | Deve estar entre `0` e `10`. |
+| `urgencia` | Obrigatória. |
+| `dataCriacao` | Obrigatória. |
+
+### Classificação de urgência
+
+A urgência é calculada com base na nota e em palavras críticas presentes na descrição.
+
+| Condição | Urgência |
+|---|---|
+| `nota <= 3` | `ALTA` |
+| Descrição contém palavra crítica | `ALTA` |
+| `nota <= 6` | `MEDIA` |
+| Demais casos | `BAIXA` |
+
+Palavras críticas consideradas:
+
+```text
+erro
+travando
+bug
+pessimo
+pessima
+horrivel
+nao funciona
+reclamacao
+insuportavel
+```
+
+A busca por palavra crítica normaliza caixa e acentos. Assim, descrições como `péssima`, `PESSIMA` ou `pessima` são tratadas de forma equivalente.
+
+### Notificação
+
+Quando o feedback é classificado como `ALTA`, o core envia uma notificação por e-mail aos administradores configurados.
+
+O fluxo de notificação foi implementado com tolerância a falhas operacionais:
+
+- se o e-mail for enviado com sucesso, registra log `ENVIADA`;
+- se o envio falhar, registra log `FALHA`;
+- o feedback permanece persistido como registro principal da avaliação;
+- o histórico de tentativas fica disponível para consulta administrativa.
+
+### Normalização dos e-mails administrativos
+
+O `EmailSender` aceita múltiplos destinatários em `app.admin-emails` usando `;` ou `,` como separadores.
+
+Exemplo:
+
+```properties
+ADMIN_EMAILS=admin1@email.com; admin2@email.com, admin3@email.com
+```
+
+O parsing:
+
+- aplica `trim`;
+- remove entradas vazias;
+- remove duplicados;
+- valida a existência de pelo menos um destinatário.
+
+### Segurança do HTML do e-mail
+
+A descrição do feedback é escapada antes de ser inserida no corpo HTML do e-mail. Isso evita que caracteres como `<`, `>`, `"`, `'` e `&` sejam interpretados como marcação HTML.
+
+---
+
+## Endpoints da API
+
+O projeto usa:
+
+```properties
+quarkus.http.root-path=api
+```
+
+Portanto, em execução local, os endpoints ficam sob `/api`.
+
+### Tabela de endpoints
+
+| Método | Endpoint | Role | Descrição |
+|---|---|---|---|
+| `POST` | `/api/avaliacoes` | `ALUNO` | Cria uma avaliação/feedback. |
+| `GET` | `/api/admin/feedbacks/{feedbackId}/notificacoes` | `ADMIN` | Lista logs de notificação de um feedback. |
+
+### 1. Criar avaliação
+
+```http
+POST /api/avaliacoes
+Authorization: Bearer <TOKEN_ALUNO>
+Content-Type: application/json
+```
+
+#### Request — avaliação baixa
+
+```json
+{
+  "descricao": "A aula foi muito boa",
+  "nota": 9
+}
+```
+
+#### Response — 201 Created
+
+```json
+{
+  "id": "a7f3ffb1-2564-4661-9767-6ccaf87bbdfa",
+  "descricao": "A aula foi muito boa",
+  "nota": 9,
+  "urgencia": "BAIXA",
+  "dataCriacao": "2026-05-16T21:26:47.551857200-03:00"
+}
+```
+
+#### Request — avaliação crítica
+
+```json
+{
+  "descricao": "A plataforma está travando durante a aula",
+  "nota": 8
+}
+```
+
+#### Response — 201 Created
+
+```json
+{
+  "id": "b3a3d6ba-c234-47b9-af77-ec35ad0bf6fe",
+  "descricao": "A plataforma está travando durante a aula",
+  "nota": 8,
+  "urgencia": "ALTA",
+  "dataCriacao": "2026-05-16T21:26:47.669058900-03:00"
+}
+```
+
+Nesse exemplo, mesmo com nota `8`, a urgência é `ALTA` porque a descrição contém a palavra crítica `travando`.
+
+#### Possíveis respostas
+
+| Status | Cenário |
+|---:|---|
+| `201` | Feedback criado com sucesso. |
+| `400` | Payload inválido, nota fora do intervalo ou descrição vazia. |
+| `401` | Usuário não autenticado. |
+| `403` | Usuário autenticado sem role `ALUNO`. |
+
+### 2. Consultar logs de notificação
+
+```http
+GET /api/admin/feedbacks/{feedbackId}/notificacoes
+Authorization: Bearer <TOKEN_ADMIN>
+Accept: application/json
+```
+
+#### Response — 200 OK
+
+```json
+[
+  {
+    "id": "c4da9f6b-83c8-44a8-b6e4-61e3fc517ff0",
+    "feedbackId": "b3a3d6ba-c234-47b9-af77-ec35ad0bf6fe",
+    "tipo": "EMAIL",
+    "status": "ENVIADA",
+    "dataTentativa": "2026-05-16T21:26:47.670000-03:00",
+    "mensagemErro": null
+  }
+]
+```
+
+#### Response — log de falha
+
+```json
+[
+  {
+    "id": "2f14e6ce-f6ab-476a-96e1-e9fc104e8ee6",
+    "feedbackId": "b3a3d6ba-c234-47b9-af77-ec35ad0bf6fe",
+    "tipo": "EMAIL",
+    "status": "FALHA",
+    "dataTentativa": "2026-05-16T21:26:47.670000-03:00",
+    "mensagemErro": "Timeout ao enviar e-mail"
+  }
+]
+```
+
+#### Possíveis respostas
+
+| Status | Cenário |
+|---:|---|
+| `200` | Lista retornada com sucesso. |
+| `200` | Lista vazia quando não houver logs para o feedback. |
+| `401` | Usuário não autenticado. |
+| `403` | Usuário autenticado sem role `ADMIN`. |
+
+---
+
+## Modelo de dados
+
+### Diagrama ER
+
+```mermaid
+erDiagram
+    FEEDBACK ||--o{ FEEDBACK_NOTIFICATION_LOG : "possui"
+
+    FEEDBACK {
+        UUID id PK
+        varchar descricao
+        int nota
+        varchar urgencia
+        timestamptz data_criacao
+    }
+
+    FEEDBACK_NOTIFICATION_LOG {
+        UUID id PK
+        UUID feedback_id FK
+        varchar tipo
+        varchar status
+        timestamptz data_tentativa
+        varchar mensagem_erro
+    }
+```
+
+### Tabela `feedback`
+
+Armazena as avaliações recebidas.
+
+| Campo | Tipo | Restrição | Descrição |
+|---|---|---|---|
+| `id` | `UUID` | PK | Identificador do feedback. |
+| `descricao` | `VARCHAR(2000)` | NOT NULL | Texto informado pelo aluno. |
+| `nota` | `INTEGER` | NOT NULL, `0 <= nota <= 10` | Nota da avaliação. |
+| `urgencia` | `VARCHAR(20)` | `BAIXA`, `MEDIA`, `ALTA` | Classificação calculada. |
+| `data_criacao` | `TIMESTAMP WITH TIME ZONE` | NOT NULL | Data de criação. |
+
+### Tabela `feedback_notification_log`
+
+Armazena as tentativas de notificação associadas a feedbacks críticos.
+
+| Campo | Tipo | Restrição | Descrição |
+|---|---|---|---|
+| `id` | `UUID` | PK | Identificador do log. |
+| `feedback_id` | `UUID` | FK para `feedback(id)` | Feedback relacionado. |
+| `tipo` | `VARCHAR(50)` | `EMAIL` | Tipo de notificação. |
+| `status` | `VARCHAR(20)` | `ENVIADA`, `FALHA` | Resultado da tentativa. |
+| `data_tentativa` | `TIMESTAMP WITH TIME ZONE` | NOT NULL | Data da tentativa. |
+| `mensagem_erro` | `VARCHAR(2000)` | NULL | Mensagem de erro quando houver falha. |
+
+---
+
+## Segurança
+
+O core usa **JWT** e controle de acesso por roles.
+
+| Endpoint | Role exigida |
+|---|---|
+| `POST /api/avaliacoes` | `ALUNO` |
+| `GET /api/admin/feedbacks/{feedbackId}/notificacoes` | `ADMIN` |
+
+### JWT
+
+O serviço valida:
+
+- issuer configurado;
+- chave pública configurada;
+- roles presentes no token.
+
+Exemplo de configuração:
+
+```properties
+mp.jwt.verify.issuer=https://feedback-login.com.br/issuer
+mp.jwt.verify.publickey=${JWT_PUBLIC_KEY:${kv//jwt-public-key}}
+```
+
+### Separação de responsabilidade
+
+O core consome tokens JWT emitidos pelo componente `az-func-feedback-login`.
+
+---
+
+## Configuração
+
+### Arquivo principal
+
+O arquivo principal fica em:
+
+```text
+src/main/resources/application.properties
+```
+
+### Variáveis principais
+
+| Variável | Descrição |
+|---|---|
+| `QUARKUS_AZURE_KEYVAULT_SECRET_ENDPOINT` | Endpoint do Azure Key Vault. |
+| `FEEDBACK_DB_KIND` | Tipo do banco, normalmente `postgresql`. |
+| `FEEDBACK_DB_URL` | URL JDBC do banco. |
+| `FEEDBACK_DB_USER` | Usuário do banco. |
+| `FEEDBACK_DB_PASSWORD` | Senha do banco. |
+| `EMAIL_CONNECTION_STRING` | Connection string do Azure Communication Email. |
+| `ADMIN_EMAILS` | Lista de e-mails dos administradores. |
+| `EMAIL_SENDER_ADDRESS` | Endereço remetente autorizado no Azure Communication Email. |
+| `EMAIL_SUBJECT` | Assunto do e-mail. |
+| `JWT_PUBLIC_KEY` | Chave pública para validação de JWT. |
+
+### Configuração sensível
+
+Valores sensíveis não devem ser versionados no Git.
+
+Em produção, banco, e-mail e chave pública JWT devem vir de:
+
+1. variáveis de ambiente; ou
+2. Azure Key Vault.
+
+### Perfil de teste
+
+Os testes usam H2 em memória e valores mockados para e-mail/JWT.
+
+Exemplo conceitual:
+
+```properties
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:feedback_test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1
+app.email.connection-string=endpoint=https://localhost;accesskey=mock
+app.admin-emails=test@example.com
+app.email.sender-address=test@example.com
+mp.jwt.verify.publickey=mock-key
+```
+
+---
+
+## Tecnologias utilizadas
+
+| Categoria | Tecnologia |
+|---|---|
+| Linguagem | Java 25 |
+| Framework | Quarkus 3.34.6 |
+| Serverless | Azure Functions HTTP |
+| Persistência | Hibernate ORM Panache |
+| Banco principal | PostgreSQL |
+| Banco de testes | H2 |
+| Migração | Flyway |
+| Segurança | JWT, RBAC, `@RolesAllowed` |
+| Segredos | Azure Key Vault |
+| E-mail | Azure Communication Email |
+| Observabilidade | Micrometer, OpenTelemetry |
+| Testes | JUnit 5, RestAssured, Quarkus Test |
+| Build | Maven |
+| Empacotamento | Azure Functions Maven Plugin |
+
+---
+
+## Como executar localmente
+
+### Pré-requisitos
+
+- Java 25;
+- Maven 3.9+;
+- Azure Functions Core Tools, caso queira executar como Function local;
+- PostgreSQL, caso execute contra banco real;
+- variáveis de ambiente configuradas ou perfil de desenvolvimento/teste com H2.
+
+### Clonar o repositório
+
+```powershell
+git clone https://github.com/KervinCandido/az-func-feedback-core.git
+cd az-func-feedback-core
+```
+
+### Rodar em modo Quarkus dev
+
+```powershell
+mvn quarkus:dev
+```
+
+A API ficará disponível em:
+
+```text
+http://localhost:8080/api
+```
+
+Exemplo:
+
+```text
+http://localhost:8080/api/avaliacoes
+```
+
+### Rodar como Azure Function local
+
+Empacote o projeto:
+
+```powershell
+mvn clean package
+```
+
+Depois, acesse o diretório gerado:
+
+```powershell
+cd target\azure-functions\func-feedback-core
+func host start
+```
+
+---
+
+## Testes
+
+### Rodar todos os testes
+
+```powershell
+mvn test
+```
+
+### Rodar build completo
+
+```powershell
+mvn clean package
+```
+
+### Rodar testes específicos
+
+```powershell
+mvn -Dtest=AvaliacaoResourceTest test
+```
+
+```powershell
+mvn -Dtest=CreateFeedbackUseCaseTest test
+```
+
+```powershell
+mvn -Dtest=AdminFeedbackNotificationLogResourceTest test
+```
+
+```powershell
+mvn -Dtest=EmailSenderTest test
+```
+
+### Última validação local registrada
+
+```text
+Tests run: 55
+Failures: 0
+Errors: 0
+Skipped: 0
+BUILD SUCCESS
+```
+
+---
+
+## Qualidade técnica
+
+### Clean Architecture / Ports and Adapters
+
+O projeto mantém as regras de negócio isoladas dos detalhes técnicos:
+
+- use cases dependem de interfaces;
+- adapters JPA implementam portas de persistência;
+- envio de e-mail é tratado por porta genérica `Notification<T>`;
+- classificação de urgência é exposta por `FeedbackUrgenciaClassifier`;
+- resources REST recebem requests, delegam para use cases e montam responses.
+
+### SOLID
+
+| Princípio | Aplicação no projeto |
+|---|---|
+| SRP | `CreateFeedbackUseCase` orquestra criação; `EmailSender` envia e-mail; repositories persistem dados. |
+| OCP | Novos tipos de notificação podem ser adicionados implementando `Notification<Feedback>`. |
+| LSP | Adapters implementam portas sem alterar contratos da aplicação. |
+| ISP | Portas pequenas e específicas, como `FeedbackRepositoryPort` e `FeedbackNotificationLogRepositoryPort`. |
+| DIP | Casos de uso dependem de abstrações, não de implementações concretas. |
+
+### Resiliência operacional
+
+A criação do feedback prioriza o registro da avaliação como dado principal do domínio. A notificação administrativa é tratada como ação operacional complementar, com registro próprio de sucesso ou falha.
+
+```text
+Receber feedback → Classificar → Persistir → Notificar se crítico → Registrar tentativa
+```
+
+Esse desenho garante rastreabilidade do fluxo sem acoplar o resultado da avaliação à disponibilidade momentânea do provedor de e-mail.
+
+### Segurança
+
+- endpoints protegidos por role;
+- JWT validado por issuer e chave pública;
+- segredos externos via variáveis/Key Vault;
+- configuração principal sem fallbacks sensíveis;
+- escape de conteúdo dinâmico no HTML do e-mail.
+
+### Testabilidade
+
+O projeto cobre:
+
+- validações do domínio `Feedback`;
+- classificação de urgência;
+- criação do feedback;
+- envio de notificações;
+- registro de logs `ENVIADA` e `FALHA`;
+- parsing de e-mails administrativos;
+- escape HTML;
+- consulta administrativa dos logs;
+- autorização `ALUNO`, `ADMIN`, `401` e `403`.
+
+---
+
+## Observabilidade
+
+O projeto possui integração com Micrometer/OpenTelemetry.
+
+Há instrumentação com `@Timed` em operações de repositório, como:
+
+- salvamento de feedback;
+- salvamento de log de notificação;
+- busca de logs por `feedbackId`.
+
+O prefixo padrão das métricas é:
+
+```properties
+feedback.metrics.prefix=feedback.core.
+```
+
+---
+
+## Roteiro de demonstração
+
+### Cenário 1 — Avaliação não crítica
+
+1. Obter token JWT com role `ALUNO`.
+2. Enviar:
+
+```http
+POST /api/avaliacoes
+```
+
+```json
+{
+  "descricao": "A aula foi muito boa",
+  "nota": 9
+}
+```
+
+3. Verificar response com `urgencia = BAIXA`.
+
+### Cenário 2 — Avaliação crítica por nota
+
+1. Obter token JWT com role `ALUNO`.
+2. Enviar:
+
+```json
+{
+  "descricao": "Não consegui acompanhar a aula",
+  "nota": 2
+}
+```
+
+3. Verificar response com `urgencia = ALTA`.
+4. Verificar a tentativa de notificação registrada no banco.
+
+### Cenário 3 — Avaliação crítica por palavra-chave
+
+1. Enviar:
+
+```json
+{
+  "descricao": "A plataforma está travando durante a aula",
+  "nota": 8
+}
+```
+
+2. Verificar `urgencia = ALTA`, mesmo com nota alta.
+3. Explicar que a palavra `travando` é crítica.
+
+### Cenário 4 — Consulta administrativa do histórico
+
+1. Obter token JWT com role `ADMIN`.
+2. Consultar:
+
+```http
+GET /api/admin/feedbacks/{feedbackId}/notificacoes
+```
+
+3. Mostrar retorno contendo `EMAIL`, `ENVIADA` ou `FALHA`.
+
+### Cenário 5 — Segurança
+
+1. Tentar criar avaliação sem token.
+2. Mostrar `401`.
+3. Tentar criar avaliação com role diferente de `ALUNO`.
+4. Mostrar `403`.
+5. Tentar consultar logs com role `ALUNO`.
+6. Mostrar `403`.
+
+---
+
+## Collections para teste
+
+Sugestão de organização:
+
+```text
+postman/
+  Feedback Platform - Core.postman_collection.json
+  Feedback Platform - Local.postman_environment.json
+```
+
+Sugestão de cenários:
+
+1. Login como aluno.
+2. Criar feedback `BAIXA`.
+3. Criar feedback `MEDIA`.
+4. Criar feedback `ALTA` por nota.
+5. Criar feedback `ALTA` por palavra crítica.
+6. Login como admin.
+7. Consultar logs de notificação.
+8. Validar 401 sem token.
+9. Validar 403 com role incorreta.
+
+---
+
+## Troubleshooting
+
+### Erro no GitHub Actions: `azure/login@v3`
+
+Se aparecer:
+
+```text
+Not all values are present. Ensure 'client-id' and 'tenant-id' are supplied.
+```
+
+Verifique os secrets do repositório:
+
+- `AZURE_CREDENTIALS`; ou
+- `AZURE_CLIENT_ID`;
+- `AZURE_TENANT_ID`;
+- `AZURE_SUBSCRIPTION_ID`;
+- `AZURE_CLIENT_SECRET`, se estiver usando Service Principal com secret.
+
+### Testes falhando por FK entre `feedback_notification_log` e `feedback`
+
+A tabela `feedback_notification_log` possui FK para `feedback`. Em testes de limpeza de banco, a ordem correta é:
+
+```java
+notificationLogRepository.deleteAll();
+feedbackRepository.deleteAll();
+```
+
+### Caracteres acentuados aparecem como `?` no console
+
+Isso geralmente está ligado ao encoding do terminal no Windows. O projeto usa UTF-8, mas o terminal pode não estar renderizando corretamente.
+
+Possível ajuste:
+
+```powershell
+chcp 65001
+```
+
+### Warning sobre `sun.misc.Unsafe`
+
+Com Java 25, algumas dependências do ecossistema Maven/Guice podem emitir warning de uso de APIs depreciadas. Esse warning não impede o build.
+
+### Warning do Flyway com H2
+
+O Flyway pode avisar que a versão do H2 é mais nova do que a última verificada. Esse warning não impede a execução dos testes.
+
+---
+
+## Estrutura de pastas
+
+Estrutura simplificada:
+
+```text
+src/
+  main/
+    java/
+      br/com/fiap/techchallenge/feedbackplatform/
+        application/
+          dto/
+          ports/
+          usecase/
+        domain/
+          enums/
+          model/
+        infrastructure/
+          classifier/
+          config/
+          notify/
+          persistence/
+          rest/
+    resources/
+      application.properties
+      db/migration/
+  test/
+    java/
+      br/com/fiap/techchallenge/feedbackplatform/
+        application/
+        domain/
+        infrastructure/
+    resources/
+      application.properties
+```
+
+---
+
+## Comandos úteis
+
+### Build
+
+```powershell
+mvn clean package
+```
+
+### Testes
+
+```powershell
+mvn clean test
+```
+
+### Rodar Quarkus dev
+
+```powershell
+mvn quarkus:dev
+```
+
+### Rodar Azure Function local
+
+```powershell
+mvn clean package
+cd target\azure-functions\func-feedback-core
+func host start
+```
+
+### Criar branch
+
+```powershell
+git checkout main
+git pull origin main
+git checkout -b docs/atualiza-readme-core
+```
+
+---
+
+## Conclusão
+
+O `az-func-feedback-core` entrega o fluxo principal de feedbacks da Fase 4 com foco em simplicidade, segurança, rastreabilidade e aderência a uma arquitetura em camadas.
+
+A solução permite que alunos enviem avaliações, classifica automaticamente a urgência, persiste os dados, dispara notificações administrativas em casos críticos e registra o histórico das tentativas de envio.
+
+A consulta administrativa dos logs torna o comportamento demonstrável e facilita auditoria técnica da solução.
+
+Este README é uma documentação viva. Em caso de evolução da API ou dos componentes Azure, recomenda-se atualizá-lo junto com o código.

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/application/dto/FeedbackNotificationLogResult.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/application/dto/FeedbackNotificationLogResult.java
@@ -1,0 +1,27 @@
+package br.com.fiap.techchallenge.feedbackplatform.application.dto;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record FeedbackNotificationLogResult(
+        UUID id,
+        UUID feedbackId,
+        FeedbackNotificationType tipo,
+        FeedbackNotificationStatus status,
+        OffsetDateTime dataTentativa,
+        String mensagemErro) {
+
+    public static FeedbackNotificationLogResult from(FeedbackNotificationLog notificationLog) {
+        return new FeedbackNotificationLogResult(
+                notificationLog.id(),
+                notificationLog.feedbackId(),
+                notificationLog.tipo(),
+                notificationLog.status(),
+                notificationLog.dataTentativa(),
+                notificationLog.mensagemErro());
+    }
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/application/ports/FeedbackNotificationLogRepositoryPort.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/application/ports/FeedbackNotificationLogRepositoryPort.java
@@ -1,0 +1,8 @@
+package br.com.fiap.techchallenge.feedbackplatform.application.ports;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
+
+public interface FeedbackNotificationLogRepositoryPort {
+
+    FeedbackNotificationLog save(FeedbackNotificationLog notificationLog);
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/application/ports/FeedbackNotificationLogRepositoryPort.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/application/ports/FeedbackNotificationLogRepositoryPort.java
@@ -2,7 +2,12 @@ package br.com.fiap.techchallenge.feedbackplatform.application.ports;
 
 import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
 
+import java.util.List;
+import java.util.UUID;
+
 public interface FeedbackNotificationLogRepositoryPort {
 
     FeedbackNotificationLog save(FeedbackNotificationLog notificationLog);
+
+    List<FeedbackNotificationLog> findByFeedbackId(UUID feedbackId);
 }

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/application/usecase/CreateFeedbackUseCase.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/application/usecase/CreateFeedbackUseCase.java
@@ -8,24 +8,30 @@ import org.slf4j.LoggerFactory;
 
 import br.com.fiap.techchallenge.feedbackplatform.application.dto.CreateFeedbackCommand;
 import br.com.fiap.techchallenge.feedbackplatform.application.dto.FeedbackCreatedResult;
+import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackNotificationLogRepositoryPort;
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackRepositoryPort;
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackUrgenciaClassifier;
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.Notification;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
 import br.com.fiap.techchallenge.feedbackplatform.domain.model.Feedback;
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
 
 public class CreateFeedbackUseCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(CreateFeedbackUseCase.class);
 
     private final FeedbackRepositoryPort feedbackRepository;
+    private final FeedbackNotificationLogRepositoryPort notificationLogRepository;
     private final FeedbackUrgenciaClassifier urgenciaClassifier;
     private final List<Notification<Feedback>> notifications;
 
     public CreateFeedbackUseCase(
             FeedbackRepositoryPort feedbackRepository,
+            FeedbackNotificationLogRepositoryPort notificationLogRepository,
             FeedbackUrgenciaClassifier urgenciaClassifier,
             List<Notification<Feedback>> notifications) {
         this.feedbackRepository = Objects.requireNonNull(feedbackRepository);
+        this.notificationLogRepository = Objects.requireNonNull(notificationLogRepository);
         this.urgenciaClassifier = Objects.requireNonNull(urgenciaClassifier);
         this.notifications = Objects.requireNonNull(notifications);
     }
@@ -51,12 +57,41 @@ public class CreateFeedbackUseCase {
         for (Notification<Feedback> notification : notifications) {
             try {
                 notification.send(feedback);
+                registrarLogDeNotificacaoSemInterromperCriacao(
+                        FeedbackNotificationLog.enviada(
+                                feedback.id(),
+                                FeedbackNotificationType.EMAIL));
             } catch (RuntimeException exception) {
                 LOG.error(
                         "Falha ao enviar notificação do feedback {}. A criação do feedback será mantida.",
                         feedback.id(),
                         exception);
+
+                registrarLogDeNotificacaoSemInterromperCriacao(
+                        FeedbackNotificationLog.falha(
+                                feedback.id(),
+                                FeedbackNotificationType.EMAIL,
+                                obterMensagemErro(exception)));
             }
         }
+    }
+
+    private void registrarLogDeNotificacaoSemInterromperCriacao(FeedbackNotificationLog notificationLog) {
+        try {
+            notificationLogRepository.save(notificationLog);
+        } catch (RuntimeException exception) {
+            LOG.error(
+                    "Falha ao registrar log de notificação do feedback {}. A criação do feedback será mantida.",
+                    notificationLog.feedbackId(),
+                    exception);
+        }
+    }
+
+    private String obterMensagemErro(RuntimeException exception) {
+        if (exception.getMessage() == null || exception.getMessage().isBlank()) {
+            return exception.getClass().getSimpleName();
+        }
+
+        return exception.getMessage();
     }
 }

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/application/usecase/ListFeedbackNotificationLogsUseCase.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/application/usecase/ListFeedbackNotificationLogsUseCase.java
@@ -1,0 +1,27 @@
+package br.com.fiap.techchallenge.feedbackplatform.application.usecase;
+
+import br.com.fiap.techchallenge.feedbackplatform.application.dto.FeedbackNotificationLogResult;
+import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackNotificationLogRepositoryPort;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public class ListFeedbackNotificationLogsUseCase {
+
+    private final FeedbackNotificationLogRepositoryPort notificationLogRepository;
+
+    public ListFeedbackNotificationLogsUseCase(
+            FeedbackNotificationLogRepositoryPort notificationLogRepository) {
+        this.notificationLogRepository = Objects.requireNonNull(notificationLogRepository);
+    }
+
+    public List<FeedbackNotificationLogResult> execute(UUID feedbackId) {
+        Objects.requireNonNull(feedbackId, "feedbackId é obrigatório");
+
+        return notificationLogRepository.findByFeedbackId(feedbackId)
+                .stream()
+                .map(FeedbackNotificationLogResult::from)
+                .toList();
+    }
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/enums/FeedbackNotificationStatus.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/enums/FeedbackNotificationStatus.java
@@ -1,0 +1,6 @@
+package br.com.fiap.techchallenge.feedbackplatform.domain.enums;
+
+public enum FeedbackNotificationStatus {
+    ENVIADA,
+    FALHA
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/enums/FeedbackNotificationType.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/enums/FeedbackNotificationType.java
@@ -1,0 +1,5 @@
+package br.com.fiap.techchallenge.feedbackplatform.domain.enums;
+
+public enum FeedbackNotificationType {
+    EMAIL
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/Feedback.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/Feedback.java
@@ -35,17 +35,6 @@ public record Feedback(
                 OffsetDateTime.now());
     }
 
-    public Feedback marcarAlertaEnviado(OffsetDateTime dataEnvioAlerta) {
-        Objects.requireNonNull(dataEnvioAlerta, "dataEnvioAlerta é obrigatória");
-
-        return new Feedback(
-                id,
-                descricao,
-                nota,
-                urgencia,
-                dataCriacao);
-    }
-
     private static void validarDescricao(String descricao) {
         if (descricao == null || descricao.isBlank()) {
             throw new IllegalArgumentException("Descrição é obrigatória.");

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackNotificationLog.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackNotificationLog.java
@@ -1,0 +1,71 @@
+package br.com.fiap.techchallenge.feedbackplatform.domain.model;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+
+public record FeedbackNotificationLog(
+        UUID id,
+        UUID feedbackId,
+        FeedbackNotificationType tipo,
+        FeedbackNotificationStatus status,
+        OffsetDateTime dataTentativa,
+        String mensagemErro) {
+
+    private static final int TAMANHO_MAXIMO_MENSAGEM_ERRO = 2000;
+
+    public FeedbackNotificationLog {
+        Objects.requireNonNull(id, "id é obrigatório");
+        Objects.requireNonNull(feedbackId, "feedbackId é obrigatório");
+        Objects.requireNonNull(tipo, "tipo é obrigatório");
+        Objects.requireNonNull(status, "status é obrigatório");
+        Objects.requireNonNull(dataTentativa, "dataTentativa é obrigatória");
+
+        if (FeedbackNotificationStatus.FALHA.equals(status)
+                && (mensagemErro == null || mensagemErro.isBlank())) {
+            throw new IllegalArgumentException("mensagemErro é obrigatória para notificações com falha.");
+        }
+
+        mensagemErro = normalizarMensagemErro(mensagemErro);
+    }
+
+    public static FeedbackNotificationLog enviada(UUID feedbackId, FeedbackNotificationType tipo) {
+        return new FeedbackNotificationLog(
+                UUID.randomUUID(),
+                feedbackId,
+                tipo,
+                FeedbackNotificationStatus.ENVIADA,
+                OffsetDateTime.now(),
+                null);
+    }
+
+    public static FeedbackNotificationLog falha(
+            UUID feedbackId,
+            FeedbackNotificationType tipo,
+            String mensagemErro) {
+        return new FeedbackNotificationLog(
+                UUID.randomUUID(),
+                feedbackId,
+                tipo,
+                FeedbackNotificationStatus.FALHA,
+                OffsetDateTime.now(),
+                mensagemErro);
+    }
+
+    private static String normalizarMensagemErro(String mensagemErro) {
+        if (mensagemErro == null || mensagemErro.isBlank()) {
+            return null;
+        }
+
+        String mensagemNormalizada = mensagemErro.trim();
+
+        if (mensagemNormalizada.length() <= TAMANHO_MAXIMO_MENSAGEM_ERRO) {
+            return mensagemNormalizada;
+        }
+
+        return mensagemNormalizada.substring(0, TAMANHO_MAXIMO_MENSAGEM_ERRO);
+    }
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/config/Producers.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/config/Producers.java
@@ -2,6 +2,7 @@ package br.com.fiap.techchallenge.feedbackplatform.infrastructure.config;
 
 import java.util.List;
 
+import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackNotificationLogRepositoryPort;
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackRepositoryPort;
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackUrgenciaClassifier;
 import br.com.fiap.techchallenge.feedbackplatform.application.usecase.CreateFeedbackUseCase;
@@ -16,11 +17,13 @@ public class Producers {
     @ApplicationScoped
     public CreateFeedbackUseCase createFeedbackUseCaseProducer(
             FeedbackRepositoryPort feedbackRepository,
+            FeedbackNotificationLogRepositoryPort notificationLogRepository,
             FeedbackUrgenciaClassifier urgenciaClassifier,
             EmailSender emailSender) {
 
         return new CreateFeedbackUseCase(
                 feedbackRepository,
+                notificationLogRepository,
                 urgenciaClassifier,
                 List.of(emailSender::send));
     }

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/config/Producers.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/config/Producers.java
@@ -6,6 +6,7 @@ import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackNoti
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackRepositoryPort;
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackUrgenciaClassifier;
 import br.com.fiap.techchallenge.feedbackplatform.application.usecase.CreateFeedbackUseCase;
+import br.com.fiap.techchallenge.feedbackplatform.application.usecase.ListFeedbackNotificationLogsUseCase;
 import br.com.fiap.techchallenge.feedbackplatform.infrastructure.notify.EmailSender;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
@@ -26,5 +27,13 @@ public class Producers {
                 notificationLogRepository,
                 urgenciaClassifier,
                 List.of(emailSender::send));
+    }
+
+    @Produces
+    @ApplicationScoped
+    public ListFeedbackNotificationLogsUseCase listFeedbackNotificationLogsUseCaseProducer(
+            FeedbackNotificationLogRepositoryPort notificationLogRepository) {
+
+        return new ListFeedbackNotificationLogsUseCase(notificationLogRepository);
     }
 }

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/config/Producers.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/config/Producers.java
@@ -3,8 +3,8 @@ package br.com.fiap.techchallenge.feedbackplatform.infrastructure.config;
 import java.util.List;
 
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackRepositoryPort;
+import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackUrgenciaClassifier;
 import br.com.fiap.techchallenge.feedbackplatform.application.usecase.CreateFeedbackUseCase;
-import br.com.fiap.techchallenge.feedbackplatform.infrastructure.classifier.FeedbackUrgenciaClassifierAdapter;
 import br.com.fiap.techchallenge.feedbackplatform.infrastructure.notify.EmailSender;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
@@ -15,8 +15,13 @@ public class Producers {
     @Produces
     @ApplicationScoped
     public CreateFeedbackUseCase createFeedbackUseCaseProducer(
-            FeedbackRepositoryPort feedbackRepository, EmailSender emailSender) {
-        return new CreateFeedbackUseCase(feedbackRepository, new FeedbackUrgenciaClassifierAdapter(),
-                List.of((feedback) -> emailSender.send(feedback)));
+            FeedbackRepositoryPort feedbackRepository,
+            FeedbackUrgenciaClassifier urgenciaClassifier,
+            EmailSender emailSender) {
+
+        return new CreateFeedbackUseCase(
+                feedbackRepository,
+                urgenciaClassifier,
+                List.of(emailSender::send));
     }
 }

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSender.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSender.java
@@ -2,6 +2,7 @@ package br.com.fiap.techchallenge.feedbackplatform.infrastructure.notify;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -27,6 +28,7 @@ public class EmailSender implements Notification<Feedback> {
     private static final Logger LOG = LoggerFactory.getLogger(EmailSender.class);
 
     private static final ZoneId ZONE_ID_SP = ZoneId.of("America/Sao_Paulo");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
 
     @Inject
     @ConfigProperty(name = "app.email.connection-string")
@@ -46,26 +48,20 @@ public class EmailSender implements Notification<Feedback> {
 
     @Override
     public void send(Feedback feedback) {
-        EmailClient emailClient = new EmailClientBuilder().connectionString(connectionString).buildClient();
+        EmailClient emailClient = new EmailClientBuilder()
+                .connectionString(connectionString)
+                .buildClient();
 
-        String[] addressesSplitted = adminEmails.split(";");
+        List<EmailAddress> addresses = extrairEmailsAdministradores(adminEmails)
+                .stream()
+                .map(EmailAddress::new)
+                .toList();
 
-        var addresses = Stream.of(addressesSplitted).map(EmailAddress::new).toList();
+        if (addresses.isEmpty()) {
+            throw new IllegalStateException("Nenhum e-mail de administrador configurado em app.admin-emails.");
+        }
 
-        String body = """
-                <html>
-                    <body>
-                        <h1>Feedback crítico recebido</h1>
-                        <p><strong>Descrição:</strong> %s</p>
-                        <p><strong>Urgência:</strong> %s</p>
-                        <p><strong>Data de envio:</strong> %s</p>
-                    </body>
-                </html>
-                """;
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
-        String dataFormatada = feedback.dataCriacao().atZoneSameInstant(ZONE_ID_SP).format(formatter);
-
-        String bodyFormatted = String.format(body, feedback.descricao(), feedback.urgencia(), dataFormatada);
+        String bodyFormatted = montarCorpoEmail(feedback);
 
         EmailMessage emailMessage = new EmailMessage()
                 .setSenderAddress(senderAddress)
@@ -77,5 +73,51 @@ public class EmailSender implements Notification<Feedback> {
         PollResponse<EmailSendResult> result = poller.waitForCompletion(java.time.Duration.ofSeconds(10));
 
         LOG.info("Email sent with message Id: {}", result.getValue().getId());
+    }
+
+    static String montarCorpoEmail(Feedback feedback) {
+        String body = """
+                <html>
+                    <body>
+                        <h1>Feedback crítico recebido</h1>
+                        <p><strong>Descrição:</strong> %s</p>
+                        <p><strong>Urgência:</strong> %s</p>
+                        <p><strong>Data de envio:</strong> %s</p>
+                    </body>
+                </html>
+                """;
+
+        String descricaoSegura = escaparHtml(feedback.descricao());
+        String urgenciaSegura = escaparHtml(feedback.urgencia().name());
+        String dataFormatada = feedback.dataCriacao()
+                .atZoneSameInstant(ZONE_ID_SP)
+                .format(FORMATTER);
+
+        return String.format(body, descricaoSegura, urgenciaSegura, dataFormatada);
+    }
+
+    static List<String> extrairEmailsAdministradores(String emailsConfigurados) {
+        if (emailsConfigurados == null || emailsConfigurados.isBlank()) {
+            return List.of();
+        }
+
+        return Stream.of(emailsConfigurados.split("[;,]"))
+                .map(String::trim)
+                .filter(email -> !email.isBlank())
+                .distinct()
+                .toList();
+    }
+
+    static String escaparHtml(String valor) {
+        if (valor == null) {
+            return "";
+        }
+
+        return valor
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
     }
 }

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/entity/FeedbackNotificationLogEntity.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/entity/FeedbackNotificationLogEntity.java
@@ -1,0 +1,90 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "feedback_notification_log")
+public class FeedbackNotificationLogEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @Column(name = "feedback_id", nullable = false)
+    private UUID feedbackId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo", nullable = false, length = 50)
+    private FeedbackNotificationType tipo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private FeedbackNotificationStatus status;
+
+    @Column(name = "data_tentativa", nullable = false)
+    private OffsetDateTime dataTentativa;
+
+    @Column(name = "mensagem_erro", length = 2000)
+    private String mensagemErro;
+
+    public FeedbackNotificationLogEntity() {
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getFeedbackId() {
+        return feedbackId;
+    }
+
+    public void setFeedbackId(UUID feedbackId) {
+        this.feedbackId = feedbackId;
+    }
+
+    public FeedbackNotificationType getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(FeedbackNotificationType tipo) {
+        this.tipo = tipo;
+    }
+
+    public FeedbackNotificationStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(FeedbackNotificationStatus status) {
+        this.status = status;
+    }
+
+    public OffsetDateTime getDataTentativa() {
+        return dataTentativa;
+    }
+
+    public void setDataTentativa(OffsetDateTime dataTentativa) {
+        this.dataTentativa = dataTentativa;
+    }
+
+    public String getMensagemErro() {
+        return mensagemErro;
+    }
+
+    public void setMensagemErro(String mensagemErro) {
+        this.mensagemErro = mensagemErro;
+    }
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/mapper/FeedbackNotificationLogPersistenceMapper.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/mapper/FeedbackNotificationLogPersistenceMapper.java
@@ -1,0 +1,30 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.mapper;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class FeedbackNotificationLogPersistenceMapper {
+
+    public FeedbackNotificationLogEntity toEntity(FeedbackNotificationLog notificationLog) {
+        FeedbackNotificationLogEntity entity = new FeedbackNotificationLogEntity();
+        entity.setId(notificationLog.id());
+        entity.setFeedbackId(notificationLog.feedbackId());
+        entity.setTipo(notificationLog.tipo());
+        entity.setStatus(notificationLog.status());
+        entity.setDataTentativa(notificationLog.dataTentativa());
+        entity.setMensagemErro(notificationLog.mensagemErro());
+        return entity;
+    }
+
+    public FeedbackNotificationLog toDomain(FeedbackNotificationLogEntity entity) {
+        return new FeedbackNotificationLog(
+                entity.getId(),
+                entity.getFeedbackId(),
+                entity.getTipo(),
+                entity.getStatus(),
+                entity.getDataTentativa(),
+                entity.getMensagemErro());
+    }
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/JpaFeedbackNotificationLogRepositoryAdapter.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/JpaFeedbackNotificationLogRepositoryAdapter.java
@@ -1,0 +1,30 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository;
+
+import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackNotificationLogRepositoryPort;
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.mapper.FeedbackNotificationLogPersistenceMapper;
+import io.micrometer.core.annotation.Timed;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class JpaFeedbackNotificationLogRepositoryAdapter implements FeedbackNotificationLogRepositoryPort {
+
+    private final PanacheFeedbackNotificationLogRepository panacheRepository;
+    private final FeedbackNotificationLogPersistenceMapper mapper;
+
+    public JpaFeedbackNotificationLogRepositoryAdapter(
+            PanacheFeedbackNotificationLogRepository panacheRepository,
+            FeedbackNotificationLogPersistenceMapper mapper) {
+        this.panacheRepository = panacheRepository;
+        this.mapper = mapper;
+    }
+
+    @Timed(value = "feedback.notification.log.repository.save", description = "Tempo de execução da gravação do log de notificação")
+    @Override
+    public FeedbackNotificationLog save(FeedbackNotificationLog notificationLog) {
+        FeedbackNotificationLogEntity entity = mapper.toEntity(notificationLog);
+        panacheRepository.persist(entity);
+        return mapper.toDomain(entity);
+    }
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/JpaFeedbackNotificationLogRepositoryAdapter.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/JpaFeedbackNotificationLogRepositoryAdapter.java
@@ -7,6 +7,9 @@ import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.map
 import io.micrometer.core.annotation.Timed;
 import jakarta.enterprise.context.ApplicationScoped;
 
+import java.util.List;
+import java.util.UUID;
+
 @ApplicationScoped
 public class JpaFeedbackNotificationLogRepositoryAdapter implements FeedbackNotificationLogRepositoryPort {
 
@@ -26,5 +29,14 @@ public class JpaFeedbackNotificationLogRepositoryAdapter implements FeedbackNoti
         FeedbackNotificationLogEntity entity = mapper.toEntity(notificationLog);
         panacheRepository.persist(entity);
         return mapper.toDomain(entity);
+    }
+
+    @Timed(value = "feedback.notification.log.repository.findByFeedbackId", description = "Tempo de execução da busca de logs por feedback")
+    @Override
+    public List<FeedbackNotificationLog> findByFeedbackId(UUID feedbackId) {
+        return panacheRepository.findByFeedbackId(feedbackId)
+                .stream()
+                .map(mapper::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/PanacheFeedbackNotificationLogRepository.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/PanacheFeedbackNotificationLogRepository.java
@@ -1,5 +1,6 @@
 package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
@@ -9,4 +10,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 @ApplicationScoped
 public class PanacheFeedbackNotificationLogRepository
         implements PanacheRepositoryBase<FeedbackNotificationLogEntity, UUID> {
+
+    public List<FeedbackNotificationLogEntity> findByFeedbackId(UUID feedbackId) {
+        return list("feedbackId = ?1 order by dataTentativa desc", feedbackId);
+    }
 }

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/PanacheFeedbackNotificationLogRepository.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/PanacheFeedbackNotificationLogRepository.java
@@ -1,0 +1,12 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository;
+
+import java.util.UUID;
+
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PanacheFeedbackNotificationLogRepository
+        implements PanacheRepositoryBase<FeedbackNotificationLogEntity, UUID> {
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AdminFeedbackNotificationLogResource.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AdminFeedbackNotificationLogResource.java
@@ -1,0 +1,39 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.rest;
+
+import br.com.fiap.techchallenge.feedbackplatform.application.usecase.ListFeedbackNotificationLogsUseCase;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.rest.dto.FeedbackNotificationLogResponse;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import java.util.List;
+import java.util.UUID;
+
+@Path("/admin/feedbacks")
+@Produces(MediaType.APPLICATION_JSON)
+public class AdminFeedbackNotificationLogResource {
+
+    private final ListFeedbackNotificationLogsUseCase listFeedbackNotificationLogsUseCase;
+
+    @Inject
+    public AdminFeedbackNotificationLogResource(
+            ListFeedbackNotificationLogsUseCase listFeedbackNotificationLogsUseCase) {
+        this.listFeedbackNotificationLogsUseCase = listFeedbackNotificationLogsUseCase;
+    }
+
+    @GET
+    @Path("/{feedbackId}/notificacoes")
+    @RolesAllowed("ADMIN")
+    public List<FeedbackNotificationLogResponse> listarNotificacoes(
+            @PathParam("feedbackId") UUID feedbackId) {
+
+        return listFeedbackNotificationLogsUseCase.execute(feedbackId)
+                .stream()
+                .map(FeedbackNotificationLogResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/dto/FeedbackNotificationLogResponse.java
+++ b/src/main/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/dto/FeedbackNotificationLogResponse.java
@@ -1,0 +1,27 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.rest.dto;
+
+import br.com.fiap.techchallenge.feedbackplatform.application.dto.FeedbackNotificationLogResult;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record FeedbackNotificationLogResponse(
+        UUID id,
+        UUID feedbackId,
+        FeedbackNotificationType tipo,
+        FeedbackNotificationStatus status,
+        OffsetDateTime dataTentativa,
+        String mensagemErro) {
+
+    public static FeedbackNotificationLogResponse from(FeedbackNotificationLogResult result) {
+        return new FeedbackNotificationLogResponse(
+                result.id(),
+                result.feedbackId(),
+                result.tipo(),
+                result.status(),
+                result.dataTentativa(),
+                result.mensagemErro());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,22 +11,22 @@ quarkus.flyway.migrate-at-start=true
 
 # Database
 quarkus.datasource.db-kind=${FEEDBACK_DB_KIND:postgresql}
-quarkus.datasource.jdbc.url=${FEEDBACK_DB_URL:${kv//FeedBackDBUrl:jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH}}
-quarkus.datasource.username=${FEEDBACK_DB_USER:${kv//FeedbackDBUser:sa}}
-quarkus.datasource.password=${FEEDBACK_DB_PASSWORD:${kv//FeedBackDBPassword:sa}}
+quarkus.datasource.jdbc.url=${FEEDBACK_DB_URL:${kv//FeedBackDBUrl}}
+quarkus.datasource.username=${FEEDBACK_DB_USER:${kv//FeedbackDBUser}}
+quarkus.datasource.password=${FEEDBACK_DB_PASSWORD:${kv//FeedBackDBPassword}}
 
 # Email
-app.email.connection-string=${kv//FeedbackDBEmailConnectionString:}
-app.admin-emails=${kv//FeedbackAdminEmailList:}
-app.email.sender-address=${kv//FeedbackEmailSenderAddress:}
-app.email.subject=${EMAIL_SUBJECT:Feedback de insatisfaÃ§Ã£o recebido - FeedBack Platform}
+app.email.connection-string=${EMAIL_CONNECTION_STRING:${kv//FeedbackDBEmailConnectionString}}
+app.admin-emails=${ADMIN_EMAILS:${kv//FeedbackAdminEmailList}}
+app.email.sender-address=${EMAIL_SENDER_ADDRESS:${kv//FeedbackEmailSenderAddress}}
+app.email.subject=${EMAIL_SUBJECT:Feedback de insatisfação recebido - FeedBack Platform}
 
 # JWT
 mp.jwt.verify.issuer=https://feedback-login.com.br/issuer
-mp.jwt.verify.publickey=${kv//jwt-public-key:mock-key}
-%test.mp.jwt.verify.publickey=mock-key
+mp.jwt.verify.publickey=${JWT_PUBLIC_KEY:${kv//jwt-public-key}}
+
 # ------------------------------------------------------------
-# Perfil DEV - execuÃ§Ã£o local com mvn quarkus:dev
+# Perfil DEV - execução local com mvn quarkus:dev
 # ------------------------------------------------------------
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:feedback_dev;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1
@@ -37,6 +37,8 @@ mp.jwt.verify.publickey=${kv//jwt-public-key:mock-key}
 %dev.app.admin-emails=test@example.com
 %dev.app.email.sender-address=test@example.com
 %dev.app.email.subject=Feedback Dev
+
+%dev.mp.jwt.verify.publickey=mock-key
 
 %dev.quarkus.otel.enabled=false
 %dev.quarkus.otel.sdk.disabled=true

--- a/src/main/resources/db/migration/V2__create_feedback_notification_log_table.sql
+++ b/src/main/resources/db/migration/V2__create_feedback_notification_log_table.sql
@@ -1,0 +1,24 @@
+CREATE TABLE feedback_notification_log (
+                                           id UUID PRIMARY KEY,
+                                           feedback_id UUID NOT NULL,
+                                           tipo VARCHAR(50) NOT NULL,
+                                           status VARCHAR(20) NOT NULL,
+                                           data_tentativa TIMESTAMP WITH TIME ZONE NOT NULL,
+                                           mensagem_erro VARCHAR(2000),
+                                           CONSTRAINT fk_feedback_notification_log_feedback
+                                               FOREIGN KEY (feedback_id) REFERENCES feedback(id),
+                                           CONSTRAINT chk_feedback_notification_type
+                                               CHECK (tipo IN ('EMAIL')),
+                                           CONSTRAINT chk_feedback_notification_status
+                                               CHECK (status IN ('ENVIADA', 'FALHA'))
+);
+
+CREATE INDEX idx_feedback_notification_log_feedback_id
+    ON feedback_notification_log (feedback_id);
+
+CREATE INDEX idx_feedback_notification_log_status
+    ON feedback_notification_log (status);
+
+CREATE INDEX idx_feedback_notification_log_data_tentativa
+    ON feedback_notification_log (data_tentativa);
+

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/application/usecase/CreateFeedbackUseCaseTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/application/usecase/CreateFeedbackUseCaseTest.java
@@ -173,8 +173,16 @@ class CreateFeedbackUseCaseTest {
     @Test
     void deveManterCriacaoMesmoQuandoRegistroDoLogFalhar() {
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
-        FeedbackNotificationLogRepositoryPort notificationLogRepository = notificationLog -> {
-            throw new RuntimeException("Falha simulada ao gravar log");
+        FeedbackNotificationLogRepositoryPort notificationLogRepository = new FeedbackNotificationLogRepositoryPort() {
+            @Override
+            public FeedbackNotificationLog save(FeedbackNotificationLog notificationLog) {
+                throw new RuntimeException("Falha simulada ao gravar log");
+            }
+
+            @Override
+            public List<FeedbackNotificationLog> findByFeedbackId(UUID feedbackId) {
+                return List.of();
+            }
         };
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.ALTA;
         List<Feedback> notificacoes = new ArrayList<>();
@@ -236,5 +244,13 @@ class CreateFeedbackUseCaseTest {
             logs.add(notificationLog);
             return notificationLog;
         }
+
+        @Override
+        public List<FeedbackNotificationLog> findByFeedbackId(UUID feedbackId) {
+            return logs.stream()
+                    .filter(log -> log.feedbackId().equals(feedbackId))
+                    .toList();
+        }
     }
+
 }

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/application/usecase/CreateFeedbackUseCaseTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/application/usecase/CreateFeedbackUseCaseTest.java
@@ -2,11 +2,14 @@ package br.com.fiap.techchallenge.feedbackplatform.application.usecase;
 
 import br.com.fiap.techchallenge.feedbackplatform.application.dto.CreateFeedbackCommand;
 import br.com.fiap.techchallenge.feedbackplatform.application.dto.FeedbackCreatedResult;
+import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackNotificationLogRepositoryPort;
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackRepositoryPort;
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackUrgenciaClassifier;
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.Notification;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
 import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
 import br.com.fiap.techchallenge.feedbackplatform.domain.model.Feedback;
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -21,12 +24,14 @@ class CreateFeedbackUseCaseTest {
     @Test
     void deveCriarSalvarFeedbackERetornarResultado() {
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
+        FakeFeedbackNotificationLogRepository notificationLogRepository = new FakeFeedbackNotificationLogRepository();
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.BAIXA;
         List<Feedback> notificacoes = new ArrayList<>();
         Notification<Feedback> notification = notificacoes::add;
 
         CreateFeedbackUseCase useCase = new CreateFeedbackUseCase(
                 repository,
+                notificationLogRepository,
                 classifier,
                 List.of(notification));
 
@@ -43,17 +48,20 @@ class CreateFeedbackUseCaseTest {
         assertEquals(result.id(), repository.feedbackSalvo.id());
 
         assertTrue(notificacoes.isEmpty());
+        assertTrue(notificationLogRepository.logs.isEmpty());
     }
 
     @Test
-    void deveNotificarQuandoFeedbackForUrgente() {
+    void deveNotificarQuandoFeedbackForUrgenteERegistrarLogEnviado() {
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
+        FakeFeedbackNotificationLogRepository notificationLogRepository = new FakeFeedbackNotificationLogRepository();
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.ALTA;
         List<Feedback> notificacoes = new ArrayList<>();
         Notification<Feedback> notification = notificacoes::add;
 
         CreateFeedbackUseCase useCase = new CreateFeedbackUseCase(
                 repository,
+                notificationLogRepository,
                 classifier,
                 List.of(notification));
 
@@ -63,17 +71,24 @@ class CreateFeedbackUseCaseTest {
         assertEquals(Urgencia.ALTA, result.urgencia());
         assertEquals(1, notificacoes.size());
         assertEquals(result.id(), notificacoes.getFirst().id());
+
+        assertEquals(1, notificationLogRepository.logs.size());
+        assertEquals(result.id(), notificationLogRepository.logs.getFirst().feedbackId());
+        assertEquals(FeedbackNotificationStatus.ENVIADA, notificationLogRepository.logs.getFirst().status());
+        assertNull(notificationLogRepository.logs.getFirst().mensagemErro());
     }
 
     @Test
-    void naoDeveNotificarQuandoFeedbackNaoForUrgente() {
+    void naoDeveNotificarNemRegistrarLogQuandoFeedbackNaoForUrgente() {
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
+        FakeFeedbackNotificationLogRepository notificationLogRepository = new FakeFeedbackNotificationLogRepository();
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.MEDIA;
         List<Feedback> notificacoes = new ArrayList<>();
         Notification<Feedback> notification = notificacoes::add;
 
         CreateFeedbackUseCase useCase = new CreateFeedbackUseCase(
                 repository,
+                notificationLogRepository,
                 classifier,
                 List.of(notification));
 
@@ -82,11 +97,13 @@ class CreateFeedbackUseCaseTest {
 
         assertEquals(Urgencia.MEDIA, result.urgencia());
         assertTrue(notificacoes.isEmpty());
+        assertTrue(notificationLogRepository.logs.isEmpty());
     }
 
     @Test
-    void deveSalvarFeedbackMesmoQuandoNotificacaoFalhar() {
+    void deveSalvarFeedbackMesmoQuandoNotificacaoFalharERegistrarLogDeFalha() {
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
+        FakeFeedbackNotificationLogRepository notificationLogRepository = new FakeFeedbackNotificationLogRepository();
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.ALTA;
         Notification<Feedback> notification = feedback -> {
             throw new RuntimeException("Falha simulada no envio da notificação");
@@ -94,6 +111,7 @@ class CreateFeedbackUseCaseTest {
 
         CreateFeedbackUseCase useCase = new CreateFeedbackUseCase(
                 repository,
+                notificationLogRepository,
                 classifier,
                 List.of(notification));
 
@@ -106,11 +124,17 @@ class CreateFeedbackUseCaseTest {
         assertEquals(result.id(), repository.feedbackSalvo.id());
         assertEquals("Sistema travando muito", repository.feedbackSalvo.descricao());
         assertEquals(2, repository.feedbackSalvo.nota());
+
+        assertEquals(1, notificationLogRepository.logs.size());
+        assertEquals(result.id(), notificationLogRepository.logs.getFirst().feedbackId());
+        assertEquals(FeedbackNotificationStatus.FALHA, notificationLogRepository.logs.getFirst().status());
+        assertEquals("Falha simulada no envio da notificação", notificationLogRepository.logs.getFirst().mensagemErro());
     }
 
     @Test
-    void deveContinuarNotificandoQuandoUmaNotificacaoFalhar() {
+    void deveContinuarNotificandoQuandoUmaNotificacaoFalharERegistrarCadaTentativa() {
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
+        FakeFeedbackNotificationLogRepository notificationLogRepository = new FakeFeedbackNotificationLogRepository();
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.ALTA;
         List<String> notificacoesExecutadas = new ArrayList<>();
 
@@ -125,6 +149,7 @@ class CreateFeedbackUseCaseTest {
 
         CreateFeedbackUseCase useCase = new CreateFeedbackUseCase(
                 repository,
+                notificationLogRepository,
                 classifier,
                 List.of(primeiraNotificacao, segundaNotificacao, terceiraNotificacao));
 
@@ -137,15 +162,48 @@ class CreateFeedbackUseCaseTest {
         assertEquals(result.id(), repository.feedbackSalvo.id());
 
         assertEquals(List.of("primeira", "segunda", "terceira"), notificacoesExecutadas);
+
+        assertEquals(3, notificationLogRepository.logs.size());
+        assertEquals(FeedbackNotificationStatus.ENVIADA, notificationLogRepository.logs.get(0).status());
+        assertEquals(FeedbackNotificationStatus.FALHA, notificationLogRepository.logs.get(1).status());
+        assertEquals(FeedbackNotificationStatus.ENVIADA, notificationLogRepository.logs.get(2).status());
+        assertEquals("Falha simulada na segunda notificação", notificationLogRepository.logs.get(1).mensagemErro());
+    }
+
+    @Test
+    void deveManterCriacaoMesmoQuandoRegistroDoLogFalhar() {
+        FakeFeedbackRepository repository = new FakeFeedbackRepository();
+        FeedbackNotificationLogRepositoryPort notificationLogRepository = notificationLog -> {
+            throw new RuntimeException("Falha simulada ao gravar log");
+        };
+        FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.ALTA;
+        List<Feedback> notificacoes = new ArrayList<>();
+        Notification<Feedback> notification = notificacoes::add;
+
+        CreateFeedbackUseCase useCase = new CreateFeedbackUseCase(
+                repository,
+                notificationLogRepository,
+                classifier,
+                List.of(notification));
+
+        FeedbackCreatedResult result = assertDoesNotThrow(() -> useCase.execute(
+                new CreateFeedbackCommand("Sistema com bug", 1)));
+
+        assertEquals(Urgencia.ALTA, result.urgencia());
+        assertNotNull(repository.feedbackSalvo);
+        assertEquals(result.id(), repository.feedbackSalvo.id());
+        assertEquals(1, notificacoes.size());
     }
 
     @Test
     void deveFalharQuandoCommandForNulo() {
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
+        FakeFeedbackNotificationLogRepository notificationLogRepository = new FakeFeedbackNotificationLogRepository();
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.BAIXA;
 
         CreateFeedbackUseCase useCase = new CreateFeedbackUseCase(
                 repository,
+                notificationLogRepository,
                 classifier,
                 List.of());
 
@@ -166,6 +224,17 @@ class CreateFeedbackUseCaseTest {
         public Optional<Feedback> findById(UUID id) {
             return Optional.ofNullable(feedbackSalvo)
                     .filter(feedback -> feedback.id().equals(id));
+        }
+    }
+
+    private static class FakeFeedbackNotificationLogRepository implements FeedbackNotificationLogRepositoryPort {
+
+        private final List<FeedbackNotificationLog> logs = new ArrayList<>();
+
+        @Override
+        public FeedbackNotificationLog save(FeedbackNotificationLog notificationLog) {
+            logs.add(notificationLog);
+            return notificationLog;
         }
     }
 }

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/application/usecase/CreateFeedbackUseCaseTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/application/usecase/CreateFeedbackUseCaseTest.java
@@ -10,7 +10,9 @@ import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificat
 import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
 import br.com.fiap.techchallenge.feedbackplatform.domain.model.Feedback;
 import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,10 +21,13 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@DisplayName("Caso de uso de criação de feedback")
 class CreateFeedbackUseCaseTest {
 
     @Test
+    @DisplayName("Deve criar e salvar feedback sem notificar quando a urgência for baixa")
     void deveCriarSalvarFeedbackERetornarResultado() {
+        // Arrange
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
         FakeFeedbackNotificationLogRepository notificationLogRepository = new FakeFeedbackNotificationLogRepository();
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.BAIXA;
@@ -35,9 +40,12 @@ class CreateFeedbackUseCaseTest {
                 classifier,
                 List.of(notification));
 
-        FeedbackCreatedResult result = useCase.execute(
-                new CreateFeedbackCommand("Aula muito boa", 9));
+        CreateFeedbackCommand command = new CreateFeedbackCommand("Aula muito boa", 9);
 
+        // Act
+        FeedbackCreatedResult result = useCase.execute(command);
+
+        // Assert
         assertNotNull(result.id());
         assertEquals("Aula muito boa", result.descricao());
         assertEquals(9, result.nota());
@@ -52,7 +60,9 @@ class CreateFeedbackUseCaseTest {
     }
 
     @Test
+    @DisplayName("Deve notificar e registrar log ENVIADA quando o feedback for urgente")
     void deveNotificarQuandoFeedbackForUrgenteERegistrarLogEnviado() {
+        // Arrange
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
         FakeFeedbackNotificationLogRepository notificationLogRepository = new FakeFeedbackNotificationLogRepository();
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.ALTA;
@@ -65,9 +75,12 @@ class CreateFeedbackUseCaseTest {
                 classifier,
                 List.of(notification));
 
-        FeedbackCreatedResult result = useCase.execute(
-                new CreateFeedbackCommand("Sistema travando", 8));
+        CreateFeedbackCommand command = new CreateFeedbackCommand("Sistema travando", 8);
 
+        // Act
+        FeedbackCreatedResult result = useCase.execute(command);
+
+        // Assert
         assertEquals(Urgencia.ALTA, result.urgencia());
         assertEquals(1, notificacoes.size());
         assertEquals(result.id(), notificacoes.getFirst().id());
@@ -79,7 +92,9 @@ class CreateFeedbackUseCaseTest {
     }
 
     @Test
+    @DisplayName("Não deve notificar nem registrar log quando o feedback não for urgente")
     void naoDeveNotificarNemRegistrarLogQuandoFeedbackNaoForUrgente() {
+        // Arrange
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
         FakeFeedbackNotificationLogRepository notificationLogRepository = new FakeFeedbackNotificationLogRepository();
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.MEDIA;
@@ -92,16 +107,21 @@ class CreateFeedbackUseCaseTest {
                 classifier,
                 List.of(notification));
 
-        FeedbackCreatedResult result = useCase.execute(
-                new CreateFeedbackCommand("Aula regular", 5));
+        CreateFeedbackCommand command = new CreateFeedbackCommand("Aula regular", 5);
 
+        // Act
+        FeedbackCreatedResult result = useCase.execute(command);
+
+        // Assert
         assertEquals(Urgencia.MEDIA, result.urgencia());
         assertTrue(notificacoes.isEmpty());
         assertTrue(notificationLogRepository.logs.isEmpty());
     }
 
     @Test
+    @DisplayName("Deve salvar feedback e registrar log FALHA quando a notificação falhar")
     void deveSalvarFeedbackMesmoQuandoNotificacaoFalharERegistrarLogDeFalha() {
+        // Arrange
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
         FakeFeedbackNotificationLogRepository notificationLogRepository = new FakeFeedbackNotificationLogRepository();
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.ALTA;
@@ -115,9 +135,12 @@ class CreateFeedbackUseCaseTest {
                 classifier,
                 List.of(notification));
 
-        FeedbackCreatedResult result = assertDoesNotThrow(() -> useCase.execute(
-                new CreateFeedbackCommand("Sistema travando muito", 2)));
+        CreateFeedbackCommand command = new CreateFeedbackCommand("Sistema travando muito", 2);
 
+        // Act
+        FeedbackCreatedResult result = assertDoesNotThrow(() -> useCase.execute(command));
+
+        // Assert
         assertEquals(Urgencia.ALTA, result.urgencia());
 
         assertNotNull(repository.feedbackSalvo);
@@ -132,7 +155,9 @@ class CreateFeedbackUseCaseTest {
     }
 
     @Test
+    @DisplayName("Deve continuar notificando quando uma notificação falhar e registrar cada tentativa")
     void deveContinuarNotificandoQuandoUmaNotificacaoFalharERegistrarCadaTentativa() {
+        // Arrange
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
         FakeFeedbackNotificationLogRepository notificationLogRepository = new FakeFeedbackNotificationLogRepository();
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.ALTA;
@@ -153,9 +178,12 @@ class CreateFeedbackUseCaseTest {
                 classifier,
                 List.of(primeiraNotificacao, segundaNotificacao, terceiraNotificacao));
 
-        FeedbackCreatedResult result = assertDoesNotThrow(() -> useCase.execute(
-                new CreateFeedbackCommand("Sistema com erro crítico", 1)));
+        CreateFeedbackCommand command = new CreateFeedbackCommand("Sistema com erro crítico", 1);
 
+        // Act
+        FeedbackCreatedResult result = assertDoesNotThrow(() -> useCase.execute(command));
+
+        // Assert
         assertEquals(Urgencia.ALTA, result.urgencia());
 
         assertNotNull(repository.feedbackSalvo);
@@ -171,7 +199,9 @@ class CreateFeedbackUseCaseTest {
     }
 
     @Test
+    @DisplayName("Deve manter a criação mesmo quando o registro do log falhar")
     void deveManterCriacaoMesmoQuandoRegistroDoLogFalhar() {
+        // Arrange
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
         FeedbackNotificationLogRepositoryPort notificationLogRepository = new FeedbackNotificationLogRepositoryPort() {
             @Override
@@ -194,9 +224,12 @@ class CreateFeedbackUseCaseTest {
                 classifier,
                 List.of(notification));
 
-        FeedbackCreatedResult result = assertDoesNotThrow(() -> useCase.execute(
-                new CreateFeedbackCommand("Sistema com bug", 1)));
+        CreateFeedbackCommand command = new CreateFeedbackCommand("Sistema com bug", 1);
 
+        // Act
+        FeedbackCreatedResult result = assertDoesNotThrow(() -> useCase.execute(command));
+
+        // Assert
         assertEquals(Urgencia.ALTA, result.urgencia());
         assertNotNull(repository.feedbackSalvo);
         assertEquals(result.id(), repository.feedbackSalvo.id());
@@ -204,7 +237,9 @@ class CreateFeedbackUseCaseTest {
     }
 
     @Test
+    @DisplayName("Deve falhar quando o comando for nulo")
     void deveFalharQuandoCommandForNulo() {
+        // Arrange
         FakeFeedbackRepository repository = new FakeFeedbackRepository();
         FakeFeedbackNotificationLogRepository notificationLogRepository = new FakeFeedbackNotificationLogRepository();
         FeedbackUrgenciaClassifier classifier = (descricao, nota) -> Urgencia.BAIXA;
@@ -215,7 +250,11 @@ class CreateFeedbackUseCaseTest {
                 classifier,
                 List.of());
 
-        assertThrows(NullPointerException.class, () -> useCase.execute(null));
+        // Act
+        Executable action = () -> useCase.execute(null);
+
+        // Assert
+        assertThrows(NullPointerException.class, action);
     }
 
     private static class FakeFeedbackRepository implements FeedbackRepositoryPort {
@@ -252,5 +291,4 @@ class CreateFeedbackUseCaseTest {
                     .toList();
         }
     }
-
 }

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/application/usecase/ListFeedbackNotificationLogsUseCaseTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/application/usecase/ListFeedbackNotificationLogsUseCaseTest.java
@@ -1,0 +1,113 @@
+package br.com.fiap.techchallenge.feedbackplatform.application.usecase;
+
+import br.com.fiap.techchallenge.feedbackplatform.application.dto.FeedbackNotificationLogResult;
+import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackNotificationLogRepositoryPort;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("Caso de uso de consulta de logs de notificação")
+class ListFeedbackNotificationLogsUseCaseTest {
+
+    @Test
+    @DisplayName("Deve listar logs de notificação do feedback informado")
+    void deveListarLogsDoFeedbackInformado() {
+        // Arrange
+        UUID feedbackId = UUID.randomUUID();
+        FakeFeedbackNotificationLogRepository repository = new FakeFeedbackNotificationLogRepository();
+
+        FeedbackNotificationLog logEnviado = new FeedbackNotificationLog(
+                UUID.randomUUID(),
+                feedbackId,
+                FeedbackNotificationType.EMAIL,
+                FeedbackNotificationStatus.ENVIADA,
+                OffsetDateTime.parse("2026-05-16T10:00:00Z"),
+                null);
+
+        FeedbackNotificationLog logFalha = new FeedbackNotificationLog(
+                UUID.randomUUID(),
+                feedbackId,
+                FeedbackNotificationType.EMAIL,
+                FeedbackNotificationStatus.FALHA,
+                OffsetDateTime.parse("2026-05-16T11:00:00Z"),
+                "Timeout ao enviar e-mail");
+
+        repository.logs.add(logEnviado);
+        repository.logs.add(logFalha);
+
+        ListFeedbackNotificationLogsUseCase useCase = new ListFeedbackNotificationLogsUseCase(repository);
+
+        // Act
+        List<FeedbackNotificationLogResult> result = useCase.execute(feedbackId);
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals(logEnviado.id(), result.get(0).id());
+        assertEquals(feedbackId, result.get(0).feedbackId());
+        assertEquals(FeedbackNotificationType.EMAIL, result.get(0).tipo());
+        assertEquals(FeedbackNotificationStatus.ENVIADA, result.get(0).status());
+        assertEquals(logEnviado.dataTentativa(), result.get(0).dataTentativa());
+        assertEquals(null, result.get(0).mensagemErro());
+
+        assertEquals(logFalha.id(), result.get(1).id());
+        assertEquals(feedbackId, result.get(1).feedbackId());
+        assertEquals(FeedbackNotificationType.EMAIL, result.get(1).tipo());
+        assertEquals(FeedbackNotificationStatus.FALHA, result.get(1).status());
+        assertEquals(logFalha.dataTentativa(), result.get(1).dataTentativa());
+        assertEquals("Timeout ao enviar e-mail", result.get(1).mensagemErro());
+    }
+
+    @Test
+    @DisplayName("Deve retornar lista vazia quando não houver logs para o feedback")
+    void deveRetornarListaVaziaQuandoNaoHouverLogsParaOFeedback() {
+        // Arrange
+        UUID feedbackId = UUID.randomUUID();
+        FakeFeedbackNotificationLogRepository repository = new FakeFeedbackNotificationLogRepository();
+        ListFeedbackNotificationLogsUseCase useCase = new ListFeedbackNotificationLogsUseCase(repository);
+
+        // Act
+        List<FeedbackNotificationLogResult> result = useCase.execute(feedbackId);
+
+        // Assert
+        assertEquals(List.of(), result);
+    }
+
+    @Test
+    @DisplayName("Deve falhar quando feedbackId for nulo")
+    void deveFalharQuandoFeedbackIdForNulo() {
+        // Arrange
+        FakeFeedbackNotificationLogRepository repository = new FakeFeedbackNotificationLogRepository();
+        ListFeedbackNotificationLogsUseCase useCase = new ListFeedbackNotificationLogsUseCase(repository);
+
+        // Act & Assert
+        assertThrows(NullPointerException.class, () -> useCase.execute(null));
+    }
+
+    private static class FakeFeedbackNotificationLogRepository implements FeedbackNotificationLogRepositoryPort {
+
+        private final List<FeedbackNotificationLog> logs = new ArrayList<>();
+
+        @Override
+        public FeedbackNotificationLog save(FeedbackNotificationLog notificationLog) {
+            logs.add(notificationLog);
+            return notificationLog;
+        }
+
+        @Override
+        public List<FeedbackNotificationLog> findByFeedbackId(UUID feedbackId) {
+            return logs.stream()
+                    .filter(log -> log.feedbackId().equals(feedbackId))
+                    .toList();
+        }
+    }
+}

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackNotificationLogTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackNotificationLogTest.java
@@ -4,11 +4,14 @@ import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificat
 import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("Domínio de log de notificação de feedback")
 class FeedbackNotificationLogTest {
@@ -56,45 +59,109 @@ class FeedbackNotificationLogTest {
     }
 
     @Test
+    @DisplayName("Deve falhar quando o id for nulo")
+    void deveFalharQuandoIdForNulo() {
+        // Arrange
+        UUID id = null;
+
+        // Act & Assert
+        assertThrows(NullPointerException.class, () ->
+                new FeedbackNotificationLog(
+                        id,
+                        UUID.randomUUID(),
+                        FeedbackNotificationType.EMAIL,
+                        FeedbackNotificationStatus.ENVIADA,
+                        OffsetDateTime.now(),
+                        null));
+    }
+
+    @Test
     @DisplayName("Deve falhar quando o feedbackId for nulo")
     void deveFalharQuandoFeedbackIdForNulo() {
         // Arrange
-        FeedbackNotificationType tipo = FeedbackNotificationType.EMAIL;
+        UUID feedbackId = null;
 
-        // Act
-        Executable action = () -> FeedbackNotificationLog.enviada(null, tipo);
-
-        // Assert
-        assertThrows(NullPointerException.class, action);
+        // Act & Assert
+        assertThrows(NullPointerException.class, () ->
+                FeedbackNotificationLog.enviada(feedbackId, FeedbackNotificationType.EMAIL));
     }
 
     @Test
     @DisplayName("Deve falhar quando o tipo for nulo")
     void deveFalharQuandoTipoForNulo() {
         // Arrange
-        UUID feedbackId = UUID.randomUUID();
+        FeedbackNotificationType tipo = null;
 
-        // Act
-        Executable action = () -> FeedbackNotificationLog.enviada(feedbackId, null);
-
-        // Assert
-        assertThrows(NullPointerException.class, action);
+        // Act & Assert
+        assertThrows(NullPointerException.class, () ->
+                FeedbackNotificationLog.enviada(UUID.randomUUID(), tipo));
     }
 
     @Test
-    @DisplayName("Deve falhar quando a mensagem de erro estiver vazia para falha")
+    @DisplayName("Deve falhar quando o status for nulo")
+    void deveFalharQuandoStatusForNulo() {
+        // Arrange
+        FeedbackNotificationStatus status = null;
+
+        // Act & Assert
+        assertThrows(NullPointerException.class, () ->
+                new FeedbackNotificationLog(
+                        UUID.randomUUID(),
+                        UUID.randomUUID(),
+                        FeedbackNotificationType.EMAIL,
+                        status,
+                        OffsetDateTime.now(),
+                        null));
+    }
+
+    @Test
+    @DisplayName("Deve falhar quando a data de tentativa for nula")
+    void deveFalharQuandoDataTentativaForNula() {
+        // Arrange
+        OffsetDateTime dataTentativa = null;
+
+        // Act & Assert
+        assertThrows(NullPointerException.class, () ->
+                new FeedbackNotificationLog(
+                        UUID.randomUUID(),
+                        UUID.randomUUID(),
+                        FeedbackNotificationType.EMAIL,
+                        FeedbackNotificationStatus.ENVIADA,
+                        dataTentativa,
+                        null));
+    }
+
+    @Test
+    @DisplayName("Deve falhar quando a mensagem de erro estiver vazia para status FALHA")
     void deveFalharQuandoMensagemErroForVaziaParaFalha() {
         // Arrange
-        UUID feedbackId = UUID.randomUUID();
+        String mensagemErro = "   ";
+
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class, () ->
+                FeedbackNotificationLog.falha(
+                        UUID.randomUUID(),
+                        FeedbackNotificationType.EMAIL,
+                        mensagemErro));
+    }
+
+    @Test
+    @DisplayName("Deve normalizar mensagem vazia para nula quando status for ENVIADA")
+    void deveNormalizarMensagemErroVaziaParaNullQuandoStatusForEnviada() {
+        // Arrange
+        String mensagemErro = "   ";
 
         // Act
-        Executable action = () -> FeedbackNotificationLog.falha(
-                feedbackId,
+        FeedbackNotificationLog log = new FeedbackNotificationLog(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
                 FeedbackNotificationType.EMAIL,
-                "   ");
+                FeedbackNotificationStatus.ENVIADA,
+                OffsetDateTime.now(),
+                mensagemErro);
 
         // Assert
-        assertThrows(IllegalArgumentException.class, action);
+        assertNull(log.mensagemErro());
     }
 
     @Test
@@ -114,7 +181,7 @@ class FeedbackNotificationLogTest {
     }
 
     @Test
-    @DisplayName("Deve remover espaços no início e no fim da mensagem de erro")
+    @DisplayName("Deve remover espaços da mensagem de erro")
     void deveRemoverEspacosDaMensagemErro() {
         // Arrange
         String mensagemErro = "   Erro ao enviar e-mail   ";

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackNotificationLogTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackNotificationLogTest.java
@@ -1,0 +1,88 @@
+package br.com.fiap.techchallenge.feedbackplatform.domain.model;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FeedbackNotificationLogTest {
+
+    @Test
+    void deveCriarLogDeNotificacaoEnviada() {
+        UUID feedbackId = UUID.randomUUID();
+
+        FeedbackNotificationLog log = FeedbackNotificationLog.enviada(
+                feedbackId,
+                FeedbackNotificationType.EMAIL);
+
+        assertNotNull(log.id());
+        assertEquals(feedbackId, log.feedbackId());
+        assertEquals(FeedbackNotificationType.EMAIL, log.tipo());
+        assertEquals(FeedbackNotificationStatus.ENVIADA, log.status());
+        assertNotNull(log.dataTentativa());
+        assertNull(log.mensagemErro());
+    }
+
+    @Test
+    void deveCriarLogDeNotificacaoComFalha() {
+        UUID feedbackId = UUID.randomUUID();
+
+        FeedbackNotificationLog log = FeedbackNotificationLog.falha(
+                feedbackId,
+                FeedbackNotificationType.EMAIL,
+                "Timeout ao enviar e-mail");
+
+        assertNotNull(log.id());
+        assertEquals(feedbackId, log.feedbackId());
+        assertEquals(FeedbackNotificationType.EMAIL, log.tipo());
+        assertEquals(FeedbackNotificationStatus.FALHA, log.status());
+        assertNotNull(log.dataTentativa());
+        assertEquals("Timeout ao enviar e-mail", log.mensagemErro());
+    }
+
+    @Test
+    void deveFalharQuandoFeedbackIdForNulo() {
+        assertThrows(NullPointerException.class, () ->
+                FeedbackNotificationLog.enviada(null, FeedbackNotificationType.EMAIL));
+    }
+
+    @Test
+    void deveFalharQuandoTipoForNulo() {
+        assertThrows(NullPointerException.class, () ->
+                FeedbackNotificationLog.enviada(UUID.randomUUID(), null));
+    }
+
+    @Test
+    void deveFalharQuandoMensagemErroForVaziaParaFalha() {
+        assertThrows(IllegalArgumentException.class, () ->
+                FeedbackNotificationLog.falha(
+                        UUID.randomUUID(),
+                        FeedbackNotificationType.EMAIL,
+                        "   "));
+    }
+
+    @Test
+    void deveLimitarMensagemErroEmDoisMilCaracteres() {
+        String mensagemLonga = "x".repeat(2500);
+
+        FeedbackNotificationLog log = FeedbackNotificationLog.falha(
+                UUID.randomUUID(),
+                FeedbackNotificationType.EMAIL,
+                mensagemLonga);
+
+        assertEquals(2000, log.mensagemErro().length());
+    }
+
+    @Test
+    void deveRemoverEspacosDaMensagemErro() {
+        FeedbackNotificationLog log = FeedbackNotificationLog.falha(
+                UUID.randomUUID(),
+                FeedbackNotificationType.EMAIL,
+                "   Erro ao enviar e-mail   ");
+
+        assertEquals("Erro ao enviar e-mail", log.mensagemErro());
+    }
+}

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackNotificationLogTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackNotificationLogTest.java
@@ -2,22 +2,29 @@ package br.com.fiap.techchallenge.feedbackplatform.domain.model;
 
 import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
 import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@DisplayName("Domínio de log de notificação de feedback")
 class FeedbackNotificationLogTest {
 
     @Test
+    @DisplayName("Deve criar log de notificação enviada")
     void deveCriarLogDeNotificacaoEnviada() {
+        // Arrange
         UUID feedbackId = UUID.randomUUID();
 
+        // Act
         FeedbackNotificationLog log = FeedbackNotificationLog.enviada(
                 feedbackId,
                 FeedbackNotificationType.EMAIL);
 
+        // Assert
         assertNotNull(log.id());
         assertEquals(feedbackId, log.feedbackId());
         assertEquals(FeedbackNotificationType.EMAIL, log.tipo());
@@ -27,62 +34,98 @@ class FeedbackNotificationLogTest {
     }
 
     @Test
+    @DisplayName("Deve criar log de notificação com falha")
     void deveCriarLogDeNotificacaoComFalha() {
+        // Arrange
         UUID feedbackId = UUID.randomUUID();
+        String mensagemErro = "Timeout ao enviar e-mail";
 
+        // Act
         FeedbackNotificationLog log = FeedbackNotificationLog.falha(
                 feedbackId,
                 FeedbackNotificationType.EMAIL,
-                "Timeout ao enviar e-mail");
+                mensagemErro);
 
+        // Assert
         assertNotNull(log.id());
         assertEquals(feedbackId, log.feedbackId());
         assertEquals(FeedbackNotificationType.EMAIL, log.tipo());
         assertEquals(FeedbackNotificationStatus.FALHA, log.status());
         assertNotNull(log.dataTentativa());
-        assertEquals("Timeout ao enviar e-mail", log.mensagemErro());
+        assertEquals(mensagemErro, log.mensagemErro());
     }
 
     @Test
+    @DisplayName("Deve falhar quando o feedbackId for nulo")
     void deveFalharQuandoFeedbackIdForNulo() {
-        assertThrows(NullPointerException.class, () ->
-                FeedbackNotificationLog.enviada(null, FeedbackNotificationType.EMAIL));
+        // Arrange
+        FeedbackNotificationType tipo = FeedbackNotificationType.EMAIL;
+
+        // Act
+        Executable action = () -> FeedbackNotificationLog.enviada(null, tipo);
+
+        // Assert
+        assertThrows(NullPointerException.class, action);
     }
 
     @Test
+    @DisplayName("Deve falhar quando o tipo for nulo")
     void deveFalharQuandoTipoForNulo() {
-        assertThrows(NullPointerException.class, () ->
-                FeedbackNotificationLog.enviada(UUID.randomUUID(), null));
+        // Arrange
+        UUID feedbackId = UUID.randomUUID();
+
+        // Act
+        Executable action = () -> FeedbackNotificationLog.enviada(feedbackId, null);
+
+        // Assert
+        assertThrows(NullPointerException.class, action);
     }
 
     @Test
+    @DisplayName("Deve falhar quando a mensagem de erro estiver vazia para falha")
     void deveFalharQuandoMensagemErroForVaziaParaFalha() {
-        assertThrows(IllegalArgumentException.class, () ->
-                FeedbackNotificationLog.falha(
-                        UUID.randomUUID(),
-                        FeedbackNotificationType.EMAIL,
-                        "   "));
+        // Arrange
+        UUID feedbackId = UUID.randomUUID();
+
+        // Act
+        Executable action = () -> FeedbackNotificationLog.falha(
+                feedbackId,
+                FeedbackNotificationType.EMAIL,
+                "   ");
+
+        // Assert
+        assertThrows(IllegalArgumentException.class, action);
     }
 
     @Test
+    @DisplayName("Deve limitar mensagem de erro em dois mil caracteres")
     void deveLimitarMensagemErroEmDoisMilCaracteres() {
+        // Arrange
         String mensagemLonga = "x".repeat(2500);
 
+        // Act
         FeedbackNotificationLog log = FeedbackNotificationLog.falha(
                 UUID.randomUUID(),
                 FeedbackNotificationType.EMAIL,
                 mensagemLonga);
 
+        // Assert
         assertEquals(2000, log.mensagemErro().length());
     }
 
     @Test
+    @DisplayName("Deve remover espaços no início e no fim da mensagem de erro")
     void deveRemoverEspacosDaMensagemErro() {
+        // Arrange
+        String mensagemErro = "   Erro ao enviar e-mail   ";
+
+        // Act
         FeedbackNotificationLog log = FeedbackNotificationLog.falha(
                 UUID.randomUUID(),
                 FeedbackNotificationType.EMAIL,
-                "   Erro ao enviar e-mail   ");
+                mensagemErro);
 
+        // Assert
         assertEquals("Erro ao enviar e-mail", log.mensagemErro());
     }
 }

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackTest.java
@@ -4,12 +4,15 @@ import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackUrge
 import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("Domínio de feedback")
 class FeedbackTest {
@@ -35,7 +38,7 @@ class FeedbackTest {
     }
 
     @Test
-    @DisplayName("Deve indicar feedback urgente quando a urgência for ALTA")
+    @DisplayName("Deve indicar que o feedback é urgente quando a urgência for ALTA")
     void deveIndicarQueFeedbackEhUrgenteQuandoUrgenciaForAlta() {
         // Arrange
         Feedback feedback = new Feedback(
@@ -53,7 +56,7 @@ class FeedbackTest {
     }
 
     @Test
-    @DisplayName("Deve indicar feedback não urgente quando a urgência não for ALTA")
+    @DisplayName("Deve indicar que o feedback não é urgente quando a urgência não for ALTA")
     void deveIndicarQueFeedbackNaoEhUrgenteQuandoUrgenciaNaoForAlta() {
         // Arrange
         Feedback feedback = new Feedback(
@@ -71,88 +74,125 @@ class FeedbackTest {
     }
 
     @Test
+    @DisplayName("Deve falhar quando o id for nulo")
+    void deveFalharQuandoIdForNulo() {
+        // Arrange
+        UUID id = null;
+
+        // Act & Assert
+        assertThrows(NullPointerException.class, () ->
+                new Feedback(
+                        id,
+                        "Comentário válido",
+                        8,
+                        Urgencia.BAIXA,
+                        OffsetDateTime.now()));
+    }
+
+    @Test
     @DisplayName("Deve falhar quando a descrição for nula")
     void deveFalharQuandoDescricaoForNula() {
         // Arrange
-        UUID id = UUID.randomUUID();
+        String descricao = null;
 
-        // Act
-        Executable action = () -> new Feedback(
-                id,
-                null,
-                8,
-                Urgencia.BAIXA,
-                OffsetDateTime.now());
-
-        // Assert
-        assertThrows(IllegalArgumentException.class, action);
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class, () ->
+                new Feedback(
+                        UUID.randomUUID(),
+                        descricao,
+                        8,
+                        Urgencia.BAIXA,
+                        OffsetDateTime.now()));
     }
 
     @Test
     @DisplayName("Deve falhar quando a descrição estiver vazia")
     void deveFalharQuandoDescricaoForVazia() {
         // Arrange
-        UUID id = UUID.randomUUID();
+        String descricao = "   ";
 
-        // Act
-        Executable action = () -> new Feedback(
-                id,
-                "   ",
-                8,
-                Urgencia.BAIXA,
-                OffsetDateTime.now());
-
-        // Assert
-        assertThrows(IllegalArgumentException.class, action);
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class, () ->
+                new Feedback(
+                        UUID.randomUUID(),
+                        descricao,
+                        8,
+                        Urgencia.BAIXA,
+                        OffsetDateTime.now()));
     }
 
     @Test
     @DisplayName("Deve falhar quando a nota for menor que zero")
     void deveFalharQuandoNotaForMenorQueZero() {
         // Arrange
-        UUID id = UUID.randomUUID();
+        int nota = -1;
 
-        // Act
-        Executable action = () -> new Feedback(
-                id,
-                "Comentário válido",
-                -1,
-                Urgencia.BAIXA,
-                OffsetDateTime.now());
-
-        // Assert
-        assertThrows(IllegalArgumentException.class, action);
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class, () ->
+                new Feedback(
+                        UUID.randomUUID(),
+                        "Comentário válido",
+                        nota,
+                        Urgencia.BAIXA,
+                        OffsetDateTime.now()));
     }
 
     @Test
     @DisplayName("Deve falhar quando a nota for maior que dez")
     void deveFalharQuandoNotaForMaiorQueDez() {
         // Arrange
-        UUID id = UUID.randomUUID();
+        int nota = 11;
 
-        // Act
-        Executable action = () -> new Feedback(
-                id,
-                "Comentário válido",
-                11,
-                Urgencia.BAIXA,
-                OffsetDateTime.now());
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class, () ->
+                new Feedback(
+                        UUID.randomUUID(),
+                        "Comentário válido",
+                        nota,
+                        Urgencia.BAIXA,
+                        OffsetDateTime.now()));
+    }
 
-        // Assert
-        assertThrows(IllegalArgumentException.class, action);
+    @Test
+    @DisplayName("Deve falhar quando a urgência for nula")
+    void deveFalharQuandoUrgenciaForNula() {
+        // Arrange
+        Urgencia urgencia = null;
+
+        // Act & Assert
+        assertThrows(NullPointerException.class, () ->
+                new Feedback(
+                        UUID.randomUUID(),
+                        "Comentário válido",
+                        8,
+                        urgencia,
+                        OffsetDateTime.now()));
+    }
+
+    @Test
+    @DisplayName("Deve falhar quando a data de criação for nula")
+    void deveFalharQuandoDataCriacaoForNula() {
+        // Arrange
+        OffsetDateTime dataCriacao = null;
+
+        // Act & Assert
+        assertThrows(NullPointerException.class, () ->
+                new Feedback(
+                        UUID.randomUUID(),
+                        "Comentário válido",
+                        8,
+                        Urgencia.BAIXA,
+                        dataCriacao));
     }
 
     @Test
     @DisplayName("Deve falhar quando o classificador for nulo")
     void deveFalharQuandoClassifierForNulo() {
         // Arrange
-        String descricao = "Comentário válido";
-        int nota = 8;
+        FeedbackUrgenciaClassifier classifier = null;
 
-        // Act
-        Executable action = () -> Feedback.novo(descricao, nota, null);
-
-        // Assert
-        assertThrows(NullPointerException.class, action);
+        // Act & Assert
+        assertThrows(NullPointerException.class, () ->
+                Feedback.novo("Comentário válido", 8, classifier));
     }
 }

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/domain/model/FeedbackTest.java
@@ -2,110 +2,157 @@ package br.com.fiap.techchallenge.feedbackplatform.domain.model;
 
 import br.com.fiap.techchallenge.feedbackplatform.application.ports.FeedbackUrgenciaClassifier;
 import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@DisplayName("Domínio de feedback")
 class FeedbackTest {
 
     private final FeedbackUrgenciaClassifier baixaClassifier = (descricao, nota) -> Urgencia.BAIXA;
 
     @Test
+    @DisplayName("Deve criar novo feedback com dados válidos")
     void deveCriarNovoFeedbackComDadosValidos() {
-        Feedback feedback = Feedback.novo("A aula foi muito boa", 9, baixaClassifier);
+        // Arrange
+        String descricao = "A aula foi muito boa";
+        int nota = 9;
 
+        // Act
+        Feedback feedback = Feedback.novo(descricao, nota, baixaClassifier);
+
+        // Assert
         assertNotNull(feedback.id());
-        assertEquals("A aula foi muito boa", feedback.descricao());
-        assertEquals(9, feedback.nota());
+        assertEquals(descricao, feedback.descricao());
+        assertEquals(nota, feedback.nota());
         assertEquals(Urgencia.BAIXA, feedback.urgencia());
         assertNotNull(feedback.dataCriacao());
     }
 
     @Test
+    @DisplayName("Deve indicar feedback urgente quando a urgência for ALTA")
     void deveIndicarQueFeedbackEhUrgenteQuandoUrgenciaForAlta() {
+        // Arrange
         Feedback feedback = new Feedback(
                 UUID.randomUUID(),
                 "Sistema travando",
                 2,
                 Urgencia.ALTA,
-                OffsetDateTime.now()
-        );
+                OffsetDateTime.now());
 
-        assertTrue(feedback.isUrgente());
+        // Act
+        boolean urgente = feedback.isUrgente();
+
+        // Assert
+        assertTrue(urgente);
     }
 
     @Test
+    @DisplayName("Deve indicar feedback não urgente quando a urgência não for ALTA")
     void deveIndicarQueFeedbackNaoEhUrgenteQuandoUrgenciaNaoForAlta() {
+        // Arrange
         Feedback feedback = new Feedback(
                 UUID.randomUUID(),
                 "Aula razoável",
                 6,
                 Urgencia.MEDIA,
-                OffsetDateTime.now()
-        );
+                OffsetDateTime.now());
 
-        assertFalse(feedback.isUrgente());
+        // Act
+        boolean urgente = feedback.isUrgente();
+
+        // Assert
+        assertFalse(urgente);
     }
 
     @Test
+    @DisplayName("Deve falhar quando a descrição for nula")
     void deveFalharQuandoDescricaoForNula() {
-        assertThrows(IllegalArgumentException.class, () ->
-                new Feedback(
-                        UUID.randomUUID(),
-                        null,
-                        8,
-                        Urgencia.BAIXA,
-                        OffsetDateTime.now()
-                )
-        );
+        // Arrange
+        UUID id = UUID.randomUUID();
+
+        // Act
+        Executable action = () -> new Feedback(
+                id,
+                null,
+                8,
+                Urgencia.BAIXA,
+                OffsetDateTime.now());
+
+        // Assert
+        assertThrows(IllegalArgumentException.class, action);
     }
 
     @Test
+    @DisplayName("Deve falhar quando a descrição estiver vazia")
     void deveFalharQuandoDescricaoForVazia() {
-        assertThrows(IllegalArgumentException.class, () ->
-                new Feedback(
-                        UUID.randomUUID(),
-                        "   ",
-                        8,
-                        Urgencia.BAIXA,
-                        OffsetDateTime.now()
-                )
-        );
+        // Arrange
+        UUID id = UUID.randomUUID();
+
+        // Act
+        Executable action = () -> new Feedback(
+                id,
+                "   ",
+                8,
+                Urgencia.BAIXA,
+                OffsetDateTime.now());
+
+        // Assert
+        assertThrows(IllegalArgumentException.class, action);
     }
 
     @Test
+    @DisplayName("Deve falhar quando a nota for menor que zero")
     void deveFalharQuandoNotaForMenorQueZero() {
-        assertThrows(IllegalArgumentException.class, () ->
-                new Feedback(
-                        UUID.randomUUID(),
-                        "Comentário válido",
-                        -1,
-                        Urgencia.BAIXA,
-                        OffsetDateTime.now()
-                )
-        );
+        // Arrange
+        UUID id = UUID.randomUUID();
+
+        // Act
+        Executable action = () -> new Feedback(
+                id,
+                "Comentário válido",
+                -1,
+                Urgencia.BAIXA,
+                OffsetDateTime.now());
+
+        // Assert
+        assertThrows(IllegalArgumentException.class, action);
     }
 
     @Test
+    @DisplayName("Deve falhar quando a nota for maior que dez")
     void deveFalharQuandoNotaForMaiorQueDez() {
-        assertThrows(IllegalArgumentException.class, () ->
-                new Feedback(
-                        UUID.randomUUID(),
-                        "Comentário válido",
-                        11,
-                        Urgencia.BAIXA,
-                        OffsetDateTime.now()
-                )
-        );
+        // Arrange
+        UUID id = UUID.randomUUID();
+
+        // Act
+        Executable action = () -> new Feedback(
+                id,
+                "Comentário válido",
+                11,
+                Urgencia.BAIXA,
+                OffsetDateTime.now());
+
+        // Assert
+        assertThrows(IllegalArgumentException.class, action);
     }
 
     @Test
+    @DisplayName("Deve falhar quando o classificador for nulo")
     void deveFalharQuandoClassifierForNulo() {
-        assertThrows(NullPointerException.class, () ->
-                Feedback.novo("Comentário válido", 8, null)
-        );
+        // Arrange
+        String descricao = "Comentário válido";
+        int nota = 8;
+
+        // Act
+        Executable action = () -> Feedback.novo(descricao, nota, null);
+
+        // Assert
+        assertThrows(NullPointerException.class, action);
     }
 }

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/classifier/FeedbackUrgenciaClassifierAdapterTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/classifier/FeedbackUrgenciaClassifierAdapterTest.java
@@ -3,7 +3,6 @@ package br.com.fiap.techchallenge.feedbackplatform.infrastructure.classifier;
 import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -70,7 +69,35 @@ class FeedbackUrgenciaClassifierAdapterTest {
     }
 
     @Test
-    @DisplayName("Deve classificar como MEDIA quando a nota for quatro")
+    @DisplayName("Deve classificar como ALTA ignorando diferenças entre maiúsculas e minúsculas")
+    void deveClassificarComoAltaIgnorandoCaixaAltaECaixaBaixa() {
+        // Arrange
+        String descricao = "O sistema apresentou BUG durante a aula";
+        int nota = 10;
+
+        // Act
+        Urgencia urgencia = classifier.classificar(descricao, nota);
+
+        // Assert
+        assertEquals(Urgencia.ALTA, urgencia);
+    }
+
+    @Test
+    @DisplayName("Deve classificar como ALTA quando a descrição contiver 'não funciona' com acento")
+    void deveClassificarComoAltaQuandoDescricaoContiverNaoFuncionaComAcento() {
+        // Arrange
+        String descricao = "A plataforma NÃO funciona corretamente";
+        int nota = 9;
+
+        // Act
+        Urgencia urgencia = classifier.classificar(descricao, nota);
+
+        // Assert
+        assertEquals(Urgencia.ALTA, urgencia);
+    }
+
+    @Test
+    @DisplayName("Deve classificar como MÉDIA quando a nota for quatro")
     void deveClassificarComoMediaQuandoNotaForQuatro() {
         // Arrange
         String descricao = "Aula regular";
@@ -84,7 +111,7 @@ class FeedbackUrgenciaClassifierAdapterTest {
     }
 
     @Test
-    @DisplayName("Deve classificar como MEDIA quando a nota for seis")
+    @DisplayName("Deve classificar como MÉDIA quando a nota for seis")
     void deveClassificarComoMediaQuandoNotaForSeis() {
         // Arrange
         String descricao = "Aula razoável";
@@ -98,7 +125,7 @@ class FeedbackUrgenciaClassifierAdapterTest {
     }
 
     @Test
-    @DisplayName("Deve classificar como BAIXA quando a nota for sete sem palavra crítica")
+    @DisplayName("Deve classificar como BAIXA quando a nota for sete e não houver palavra crítica")
     void deveClassificarComoBaixaQuandoNotaForSeteSemPalavraCritica() {
         // Arrange
         String descricao = "Aula boa";
@@ -112,7 +139,7 @@ class FeedbackUrgenciaClassifierAdapterTest {
     }
 
     @Test
-    @DisplayName("Deve classificar como BAIXA quando a nota for dez sem palavra crítica")
+    @DisplayName("Deve classificar como BAIXA quando a nota for dez e não houver palavra crítica")
     void deveClassificarComoBaixaQuandoNotaForDezSemPalavraCritica() {
         // Arrange
         String descricao = "Aula excelente";
@@ -126,30 +153,52 @@ class FeedbackUrgenciaClassifierAdapterTest {
     }
 
     @Test
+    @DisplayName("Deve classificar como BAIXA quando a descrição for nula e a nota for alta")
+    void deveClassificarComoBaixaQuandoDescricaoForNulaENotaAlta() {
+        // Arrange
+        String descricao = null;
+        int nota = 9;
+
+        // Act
+        Urgencia urgencia = classifier.classificar(descricao, nota);
+
+        // Assert
+        assertEquals(Urgencia.BAIXA, urgencia);
+    }
+
+    @Test
+    @DisplayName("Deve classificar como BAIXA quando a descrição for vazia e a nota for alta")
+    void deveClassificarComoBaixaQuandoDescricaoForVaziaENotaAlta() {
+        // Arrange
+        String descricao = "   ";
+        int nota = 9;
+
+        // Act
+        Urgencia urgencia = classifier.classificar(descricao, nota);
+
+        // Assert
+        assertEquals(Urgencia.BAIXA, urgencia);
+    }
+
+    @Test
     @DisplayName("Deve falhar quando a nota for menor que zero")
     void deveFalharQuandoNotaForMenorQueZero() {
         // Arrange
-        String descricao = "Teste";
         int nota = -1;
 
-        // Act
-        Executable action = () -> classifier.classificar(descricao, nota);
-
-        // Assert
-        assertThrows(IllegalArgumentException.class, action);
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class,
+                () -> classifier.classificar("Teste", nota));
     }
 
     @Test
     @DisplayName("Deve falhar quando a nota for maior que dez")
     void deveFalharQuandoNotaForMaiorQueDez() {
         // Arrange
-        String descricao = "Teste";
         int nota = 11;
 
-        // Act
-        Executable action = () -> classifier.classificar(descricao, nota);
-
-        // Assert
-        assertThrows(IllegalArgumentException.class, action);
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class,
+                () -> classifier.classificar("Teste", nota));
     }
 }

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/classifier/FeedbackUrgenciaClassifierAdapterTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/classifier/FeedbackUrgenciaClassifierAdapterTest.java
@@ -1,80 +1,155 @@
 package br.com.fiap.techchallenge.feedbackplatform.infrastructure.classifier;
 
 import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@DisplayName("Classificador de urgência de feedback")
 class FeedbackUrgenciaClassifierAdapterTest {
 
     private final FeedbackUrgenciaClassifierAdapter classifier = new FeedbackUrgenciaClassifierAdapter();
 
     @Test
+    @DisplayName("Deve classificar como ALTA quando a nota for zero")
     void deveClassificarComoAltaQuandoNotaForZero() {
-        Urgencia urgencia = classifier.classificar("Aula ruim", 0);
+        // Arrange
+        String descricao = "Aula ruim";
+        int nota = 0;
 
+        // Act
+        Urgencia urgencia = classifier.classificar(descricao, nota);
+
+        // Assert
         assertEquals(Urgencia.ALTA, urgencia);
     }
 
     @Test
+    @DisplayName("Deve classificar como ALTA quando a nota for três")
     void deveClassificarComoAltaQuandoNotaForTres() {
-        Urgencia urgencia = classifier.classificar("Aula abaixo do esperado", 3);
+        // Arrange
+        String descricao = "Aula abaixo do esperado";
+        int nota = 3;
 
+        // Act
+        Urgencia urgencia = classifier.classificar(descricao, nota);
+
+        // Assert
         assertEquals(Urgencia.ALTA, urgencia);
     }
 
     @Test
+    @DisplayName("Deve classificar como ALTA quando a descrição contiver palavra crítica")
     void deveClassificarComoAltaQuandoDescricaoContiverPalavraCritica() {
-        Urgencia urgencia = classifier.classificar("O sistema está travando muito", 8);
+        // Arrange
+        String descricao = "O sistema está travando muito";
+        int nota = 8;
 
+        // Act
+        Urgencia urgencia = classifier.classificar(descricao, nota);
+
+        // Assert
         assertEquals(Urgencia.ALTA, urgencia);
     }
 
     @Test
+    @DisplayName("Deve classificar como ALTA mesmo com palavra crítica acentuada")
     void deveClassificarComoAltaMesmoComPalavraCriticaAcentuada() {
-        Urgencia urgencia = classifier.classificar("A experiência foi péssima", 9);
+        // Arrange
+        String descricao = "A experiência foi péssima";
+        int nota = 9;
 
+        // Act
+        Urgencia urgencia = classifier.classificar(descricao, nota);
+
+        // Assert
         assertEquals(Urgencia.ALTA, urgencia);
     }
 
     @Test
+    @DisplayName("Deve classificar como MEDIA quando a nota for quatro")
     void deveClassificarComoMediaQuandoNotaForQuatro() {
-        Urgencia urgencia = classifier.classificar("Aula regular", 4);
+        // Arrange
+        String descricao = "Aula regular";
+        int nota = 4;
 
+        // Act
+        Urgencia urgencia = classifier.classificar(descricao, nota);
+
+        // Assert
         assertEquals(Urgencia.MEDIA, urgencia);
     }
 
     @Test
+    @DisplayName("Deve classificar como MEDIA quando a nota for seis")
     void deveClassificarComoMediaQuandoNotaForSeis() {
-        Urgencia urgencia = classifier.classificar("Aula razoável", 6);
+        // Arrange
+        String descricao = "Aula razoável";
+        int nota = 6;
 
+        // Act
+        Urgencia urgencia = classifier.classificar(descricao, nota);
+
+        // Assert
         assertEquals(Urgencia.MEDIA, urgencia);
     }
 
     @Test
+    @DisplayName("Deve classificar como BAIXA quando a nota for sete sem palavra crítica")
     void deveClassificarComoBaixaQuandoNotaForSeteSemPalavraCritica() {
-        Urgencia urgencia = classifier.classificar("Aula boa", 7);
+        // Arrange
+        String descricao = "Aula boa";
+        int nota = 7;
 
+        // Act
+        Urgencia urgencia = classifier.classificar(descricao, nota);
+
+        // Assert
         assertEquals(Urgencia.BAIXA, urgencia);
     }
 
     @Test
+    @DisplayName("Deve classificar como BAIXA quando a nota for dez sem palavra crítica")
     void deveClassificarComoBaixaQuandoNotaForDezSemPalavraCritica() {
-        Urgencia urgencia = classifier.classificar("Aula excelente", 10);
+        // Arrange
+        String descricao = "Aula excelente";
+        int nota = 10;
 
+        // Act
+        Urgencia urgencia = classifier.classificar(descricao, nota);
+
+        // Assert
         assertEquals(Urgencia.BAIXA, urgencia);
     }
 
     @Test
+    @DisplayName("Deve falhar quando a nota for menor que zero")
     void deveFalharQuandoNotaForMenorQueZero() {
-        assertThrows(IllegalArgumentException.class,
-                () -> classifier.classificar("Teste", -1));
+        // Arrange
+        String descricao = "Teste";
+        int nota = -1;
+
+        // Act
+        Executable action = () -> classifier.classificar(descricao, nota);
+
+        // Assert
+        assertThrows(IllegalArgumentException.class, action);
     }
 
     @Test
+    @DisplayName("Deve falhar quando a nota for maior que dez")
     void deveFalharQuandoNotaForMaiorQueDez() {
-        assertThrows(IllegalArgumentException.class,
-                () -> classifier.classificar("Teste", 11));
+        // Arrange
+        String descricao = "Teste";
+        int nota = 11;
+
+        // Act
+        Executable action = () -> classifier.classificar(descricao, nota);
+
+        // Assert
+        assertThrows(IllegalArgumentException.class, action);
     }
 }

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSenderTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSenderTest.java
@@ -1,0 +1,95 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.notify;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.Feedback;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EmailSenderTest {
+
+    @Test
+    void deveExtrairEmailsSeparadosPorPontoEVirgulaEVirgulaAplicandoTrim() {
+        List<String> emails = EmailSender.extrairEmailsAdministradores(
+                "admin1@example.com; admin2@example.com, admin3@example.com");
+
+        assertEquals(
+                List.of(
+                        "admin1@example.com",
+                        "admin2@example.com",
+                        "admin3@example.com"),
+                emails);
+    }
+
+    @Test
+    void deveIgnorarEmailsVazios() {
+        List<String> emails = EmailSender.extrairEmailsAdministradores(
+                "admin1@example.com; ; , admin2@example.com,, ");
+
+        assertEquals(
+                List.of(
+                        "admin1@example.com",
+                        "admin2@example.com"),
+                emails);
+    }
+
+    @Test
+    void deveRemoverEmailsDuplicados() {
+        List<String> emails = EmailSender.extrairEmailsAdministradores(
+                "admin@example.com; admin@example.com, outro@example.com");
+
+        assertEquals(
+                List.of(
+                        "admin@example.com",
+                        "outro@example.com"),
+                emails);
+    }
+
+    @Test
+    void deveRetornarListaVaziaQuandoEmailsNaoForemConfigurados() {
+        assertEquals(List.of(), EmailSender.extrairEmailsAdministradores(null));
+        assertEquals(List.of(), EmailSender.extrairEmailsAdministradores(""));
+        assertEquals(List.of(), EmailSender.extrairEmailsAdministradores("   "));
+    }
+
+    @Test
+    void deveEscaparConteudoHtml() {
+        String descricao = "<script>alert('x')</script> & \"teste\"";
+
+        String descricaoEscapada = EmailSender.escaparHtml(descricao);
+
+        assertEquals(
+                "&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt; &amp; &quot;teste&quot;",
+                descricaoEscapada);
+    }
+
+    @Test
+    void deveRetornarStringVaziaQuandoValorHtmlForNulo() {
+        assertEquals("", EmailSender.escaparHtml(null));
+    }
+
+    @Test
+    void deveMontarCorpoDoEmailComDescricaoEscapada() {
+        Feedback feedback = new Feedback(
+                UUID.randomUUID(),
+                "<b>Erro crítico</b> & problema no sistema",
+                2,
+                Urgencia.ALTA,
+                OffsetDateTime.parse("2026-05-16T15:30:00Z"));
+
+        String body = EmailSender.montarCorpoEmail(feedback);
+
+        assertFalse(body.contains("<b>Erro crítico</b>"));
+        assertFalse(body.contains("& problema no sistema"));
+
+        assertTrue(body.contains("&lt;b&gt;Erro crítico&lt;/b&gt; &amp; problema no sistema"));
+        assertTrue(body.contains("ALTA"));
+        assertTrue(body.contains("16/05/2026"));
+    }
+}

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSenderTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/notify/EmailSenderTest.java
@@ -2,6 +2,7 @@ package br.com.fiap.techchallenge.feedbackplatform.infrastructure.notify;
 
 import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
 import br.com.fiap.techchallenge.feedbackplatform.domain.model.Feedback;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
@@ -12,13 +13,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisplayName("Envio de e-mail de notificação")
 class EmailSenderTest {
 
     @Test
+    @DisplayName("Deve extrair e-mails separados por ponto e vírgula e vírgula aplicando trim")
     void deveExtrairEmailsSeparadosPorPontoEVirgulaEVirgulaAplicandoTrim() {
-        List<String> emails = EmailSender.extrairEmailsAdministradores(
-                "admin1@example.com; admin2@example.com, admin3@example.com");
+        // Arrange
+        String emailsConfigurados = "admin1@example.com; admin2@example.com, admin3@example.com";
 
+        // Act
+        List<String> emails = EmailSender.extrairEmailsAdministradores(emailsConfigurados);
+
+        // Assert
         assertEquals(
                 List.of(
                         "admin1@example.com",
@@ -28,10 +35,15 @@ class EmailSenderTest {
     }
 
     @Test
+    @DisplayName("Deve ignorar e-mails vazios")
     void deveIgnorarEmailsVazios() {
-        List<String> emails = EmailSender.extrairEmailsAdministradores(
-                "admin1@example.com; ; , admin2@example.com,, ");
+        // Arrange
+        String emailsConfigurados = "admin1@example.com; ; , admin2@example.com,, ";
 
+        // Act
+        List<String> emails = EmailSender.extrairEmailsAdministradores(emailsConfigurados);
+
+        // Assert
         assertEquals(
                 List.of(
                         "admin1@example.com",
@@ -40,10 +52,15 @@ class EmailSenderTest {
     }
 
     @Test
+    @DisplayName("Deve remover e-mails duplicados")
     void deveRemoverEmailsDuplicados() {
-        List<String> emails = EmailSender.extrairEmailsAdministradores(
-                "admin@example.com; admin@example.com, outro@example.com");
+        // Arrange
+        String emailsConfigurados = "admin@example.com; admin@example.com, outro@example.com";
 
+        // Act
+        List<String> emails = EmailSender.extrairEmailsAdministradores(emailsConfigurados);
+
+        // Assert
         assertEquals(
                 List.of(
                         "admin@example.com",
@@ -52,30 +69,56 @@ class EmailSenderTest {
     }
 
     @Test
+    @DisplayName("Deve retornar lista vazia quando e-mails não forem configurados")
     void deveRetornarListaVaziaQuandoEmailsNaoForemConfigurados() {
-        assertEquals(List.of(), EmailSender.extrairEmailsAdministradores(null));
-        assertEquals(List.of(), EmailSender.extrairEmailsAdministradores(""));
-        assertEquals(List.of(), EmailSender.extrairEmailsAdministradores("   "));
+        // Arrange
+        String emailsNulos = null;
+        String emailsVazios = "";
+        String emailsEmBranco = "   ";
+
+        // Act
+        List<String> resultadoNulo = EmailSender.extrairEmailsAdministradores(emailsNulos);
+        List<String> resultadoVazio = EmailSender.extrairEmailsAdministradores(emailsVazios);
+        List<String> resultadoEmBranco = EmailSender.extrairEmailsAdministradores(emailsEmBranco);
+
+        // Assert
+        assertEquals(List.of(), resultadoNulo);
+        assertEquals(List.of(), resultadoVazio);
+        assertEquals(List.of(), resultadoEmBranco);
     }
 
     @Test
+    @DisplayName("Deve escapar conteúdo HTML")
     void deveEscaparConteudoHtml() {
+        // Arrange
         String descricao = "<script>alert('x')</script> & \"teste\"";
 
+        // Act
         String descricaoEscapada = EmailSender.escaparHtml(descricao);
 
+        // Assert
         assertEquals(
                 "&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt; &amp; &quot;teste&quot;",
                 descricaoEscapada);
     }
 
     @Test
+    @DisplayName("Deve retornar string vazia quando valor HTML for nulo")
     void deveRetornarStringVaziaQuandoValorHtmlForNulo() {
-        assertEquals("", EmailSender.escaparHtml(null));
+        // Arrange
+        String valor = null;
+
+        // Act
+        String resultado = EmailSender.escaparHtml(valor);
+
+        // Assert
+        assertEquals("", resultado);
     }
 
     @Test
+    @DisplayName("Deve montar corpo do e-mail com descrição escapada")
     void deveMontarCorpoDoEmailComDescricaoEscapada() {
+        // Arrange
         Feedback feedback = new Feedback(
                 UUID.randomUUID(),
                 "<b>Erro crítico</b> & problema no sistema",
@@ -83,8 +126,10 @@ class EmailSenderTest {
                 Urgencia.ALTA,
                 OffsetDateTime.parse("2026-05-16T15:30:00Z"));
 
+        // Act
         String body = EmailSender.montarCorpoEmail(feedback);
 
+        // Assert
         assertFalse(body.contains("<b>Erro crítico</b>"));
         assertFalse(body.contains("& problema no sistema"));
 

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/mapper/FeedbackNotificationLogPersistenceMapperTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/mapper/FeedbackNotificationLogPersistenceMapperTest.java
@@ -1,0 +1,66 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.mapper;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class FeedbackNotificationLogPersistenceMapperTest {
+
+    private final FeedbackNotificationLogPersistenceMapper mapper = new FeedbackNotificationLogPersistenceMapper();
+
+    @Test
+    void deveConverterDominioParaEntidade() {
+        UUID id = UUID.randomUUID();
+        UUID feedbackId = UUID.randomUUID();
+        OffsetDateTime dataTentativa = OffsetDateTime.now();
+
+        FeedbackNotificationLog notificationLog = new FeedbackNotificationLog(
+                id,
+                feedbackId,
+                FeedbackNotificationType.EMAIL,
+                FeedbackNotificationStatus.FALHA,
+                dataTentativa,
+                "Falha ao enviar e-mail");
+
+        FeedbackNotificationLogEntity entity = mapper.toEntity(notificationLog);
+
+        assertEquals(id, entity.getId());
+        assertEquals(feedbackId, entity.getFeedbackId());
+        assertEquals(FeedbackNotificationType.EMAIL, entity.getTipo());
+        assertEquals(FeedbackNotificationStatus.FALHA, entity.getStatus());
+        assertEquals(dataTentativa, entity.getDataTentativa());
+        assertEquals("Falha ao enviar e-mail", entity.getMensagemErro());
+    }
+
+    @Test
+    void deveConverterEntidadeParaDominio() {
+        UUID id = UUID.randomUUID();
+        UUID feedbackId = UUID.randomUUID();
+        OffsetDateTime dataTentativa = OffsetDateTime.now();
+
+        FeedbackNotificationLogEntity entity = new FeedbackNotificationLogEntity();
+        entity.setId(id);
+        entity.setFeedbackId(feedbackId);
+        entity.setTipo(FeedbackNotificationType.EMAIL);
+        entity.setStatus(FeedbackNotificationStatus.ENVIADA);
+        entity.setDataTentativa(dataTentativa);
+        entity.setMensagemErro(null);
+
+        FeedbackNotificationLog notificationLog = mapper.toDomain(entity);
+
+        assertEquals(id, notificationLog.id());
+        assertEquals(feedbackId, notificationLog.feedbackId());
+        assertEquals(FeedbackNotificationType.EMAIL, notificationLog.tipo());
+        assertEquals(FeedbackNotificationStatus.ENVIADA, notificationLog.status());
+        assertEquals(dataTentativa, notificationLog.dataTentativa());
+        assertNull(notificationLog.mensagemErro());
+    }
+}

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/mapper/FeedbackNotificationLogPersistenceMapperTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/mapper/FeedbackNotificationLogPersistenceMapperTest.java
@@ -4,6 +4,7 @@ import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificat
 import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
 import br.com.fiap.techchallenge.feedbackplatform.domain.model.FeedbackNotificationLog;
 import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
@@ -12,12 +13,15 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@DisplayName("Mapper de persistência do log de notificação")
 class FeedbackNotificationLogPersistenceMapperTest {
 
     private final FeedbackNotificationLogPersistenceMapper mapper = new FeedbackNotificationLogPersistenceMapper();
 
     @Test
+    @DisplayName("Deve converter domínio para entidade")
     void deveConverterDominioParaEntidade() {
+        // Arrange
         UUID id = UUID.randomUUID();
         UUID feedbackId = UUID.randomUUID();
         OffsetDateTime dataTentativa = OffsetDateTime.now();
@@ -30,8 +34,10 @@ class FeedbackNotificationLogPersistenceMapperTest {
                 dataTentativa,
                 "Falha ao enviar e-mail");
 
+        // Act
         FeedbackNotificationLogEntity entity = mapper.toEntity(notificationLog);
 
+        // Assert
         assertEquals(id, entity.getId());
         assertEquals(feedbackId, entity.getFeedbackId());
         assertEquals(FeedbackNotificationType.EMAIL, entity.getTipo());
@@ -41,7 +47,9 @@ class FeedbackNotificationLogPersistenceMapperTest {
     }
 
     @Test
+    @DisplayName("Deve converter entidade para domínio")
     void deveConverterEntidadeParaDominio() {
+        // Arrange
         UUID id = UUID.randomUUID();
         UUID feedbackId = UUID.randomUUID();
         OffsetDateTime dataTentativa = OffsetDateTime.now();
@@ -54,8 +62,10 @@ class FeedbackNotificationLogPersistenceMapperTest {
         entity.setDataTentativa(dataTentativa);
         entity.setMensagemErro(null);
 
+        // Act
         FeedbackNotificationLog notificationLog = mapper.toDomain(entity);
 
+        // Assert
         assertEquals(id, notificationLog.id());
         assertEquals(feedbackId, notificationLog.feedbackId());
         assertEquals(FeedbackNotificationType.EMAIL, notificationLog.tipo());

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/mapper/FeedbackPersistenceMapperTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/mapper/FeedbackPersistenceMapperTest.java
@@ -1,0 +1,68 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.mapper;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
+import br.com.fiap.techchallenge.feedbackplatform.domain.model.Feedback;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("Mapper de persistência de feedback")
+class FeedbackPersistenceMapperTest {
+
+    private final FeedbackPersistenceMapper mapper = new FeedbackPersistenceMapper();
+
+    @Test
+    @DisplayName("Deve converter domínio para entidade")
+    void deveConverterDominioParaEntidade() {
+        // Arrange
+        UUID id = UUID.randomUUID();
+        OffsetDateTime dataCriacao = OffsetDateTime.parse("2026-05-16T15:30:00Z");
+
+        Feedback feedback = new Feedback(
+                id,
+                "A plataforma está travando durante a aula",
+                8,
+                Urgencia.ALTA,
+                dataCriacao);
+
+        // Act
+        FeedbackEntity entity = mapper.toEntity(feedback);
+
+        // Assert
+        assertEquals(id, entity.getId());
+        assertEquals("A plataforma está travando durante a aula", entity.getDescricao());
+        assertEquals(8, entity.getNota());
+        assertEquals(Urgencia.ALTA, entity.getUrgencia());
+        assertEquals(dataCriacao, entity.getDataCriacao());
+    }
+
+    @Test
+    @DisplayName("Deve converter entidade para domínio")
+    void deveConverterEntidadeParaDominio() {
+        // Arrange
+        UUID id = UUID.randomUUID();
+        OffsetDateTime dataCriacao = OffsetDateTime.parse("2026-05-16T15:30:00Z");
+
+        FeedbackEntity entity = new FeedbackEntity();
+        entity.setId(id);
+        entity.setDescricao("Aula muito boa");
+        entity.setNota(9);
+        entity.setUrgencia(Urgencia.BAIXA);
+        entity.setDataCriacao(dataCriacao);
+
+        // Act
+        Feedback feedback = mapper.toDomain(entity);
+
+        // Assert
+        assertEquals(id, feedback.id());
+        assertEquals("Aula muito boa", feedback.descricao());
+        assertEquals(9, feedback.nota());
+        assertEquals(Urgencia.BAIXA, feedback.urgencia());
+        assertEquals(dataCriacao, feedback.dataCriacao());
+    }
+}

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/PanacheFeedbackNotificationLogRepositoryTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/persistence/repository/PanacheFeedbackNotificationLogRepositoryTest.java
@@ -1,0 +1,127 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackEntity;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@DisplayName("Repository Panache de logs de notificação")
+class PanacheFeedbackNotificationLogRepositoryTest {
+
+    @Inject
+    PanacheFeedbackRepository feedbackRepository;
+
+    @Inject
+    PanacheFeedbackNotificationLogRepository notificationLogRepository;
+
+    @BeforeEach
+    void limparBanco() {
+        QuarkusTransaction.requiringNew().run(() -> {
+            notificationLogRepository.deleteAll();
+            feedbackRepository.deleteAll();
+        });
+    }
+
+    @Test
+    @DisplayName("Deve listar logs do feedback ordenados por data de tentativa decrescente")
+    void deveListarLogsDoFeedbackOrdenadosPorDataTentativaDecrescente() {
+        // Arrange
+        UUID feedbackId = UUID.randomUUID();
+        UUID outroFeedbackId = UUID.randomUUID();
+
+        UUID logMaisAntigoId = UUID.randomUUID();
+        UUID logMaisRecenteId = UUID.randomUUID();
+        UUID logIntermediarioId = UUID.randomUUID();
+
+        QuarkusTransaction.requiringNew().run(() -> {
+            feedbackRepository.persist(criarFeedback(feedbackId, "Sistema com erro crítico"));
+            feedbackRepository.persist(criarFeedback(outroFeedbackId, "Outro feedback crítico"));
+
+            notificationLogRepository.persist(criarLog(
+                    logMaisAntigoId,
+                    feedbackId,
+                    FeedbackNotificationStatus.ENVIADA,
+                    OffsetDateTime.parse("2026-05-16T09:00:00Z"),
+                    null));
+
+            notificationLogRepository.persist(criarLog(
+                    logMaisRecenteId,
+                    feedbackId,
+                    FeedbackNotificationStatus.FALHA,
+                    OffsetDateTime.parse("2026-05-16T11:00:00Z"),
+                    "Timeout ao enviar e-mail"));
+
+            notificationLogRepository.persist(criarLog(
+                    logIntermediarioId,
+                    feedbackId,
+                    FeedbackNotificationStatus.ENVIADA,
+                    OffsetDateTime.parse("2026-05-16T10:00:00Z"),
+                    null));
+
+            notificationLogRepository.persist(criarLog(
+                    UUID.randomUUID(),
+                    outroFeedbackId,
+                    FeedbackNotificationStatus.ENVIADA,
+                    OffsetDateTime.parse("2026-05-16T12:00:00Z"),
+                    null));
+        });
+
+        // Act
+        List<FeedbackNotificationLogEntity> logs = notificationLogRepository.findByFeedbackId(feedbackId);
+
+        // Assert
+        assertEquals(3, logs.size());
+        assertEquals(logMaisRecenteId, logs.get(0).getId());
+        assertEquals(OffsetDateTime.parse("2026-05-16T11:00:00Z"), logs.get(0).getDataTentativa());
+        assertEquals(FeedbackNotificationStatus.FALHA, logs.get(0).getStatus());
+
+        assertEquals(logIntermediarioId, logs.get(1).getId());
+        assertEquals(OffsetDateTime.parse("2026-05-16T10:00:00Z"), logs.get(1).getDataTentativa());
+        assertEquals(FeedbackNotificationStatus.ENVIADA, logs.get(1).getStatus());
+
+        assertEquals(logMaisAntigoId, logs.get(2).getId());
+        assertEquals(OffsetDateTime.parse("2026-05-16T09:00:00Z"), logs.get(2).getDataTentativa());
+        assertEquals(FeedbackNotificationStatus.ENVIADA, logs.get(2).getStatus());
+    }
+
+    private FeedbackEntity criarFeedback(UUID id, String descricao) {
+        FeedbackEntity feedback = new FeedbackEntity();
+        feedback.setId(id);
+        feedback.setDescricao(descricao);
+        feedback.setNota(2);
+        feedback.setUrgencia(Urgencia.ALTA);
+        feedback.setDataCriacao(OffsetDateTime.parse("2026-05-16T08:00:00Z"));
+        return feedback;
+    }
+
+    private FeedbackNotificationLogEntity criarLog(
+            UUID id,
+            UUID feedbackId,
+            FeedbackNotificationStatus status,
+            OffsetDateTime dataTentativa,
+            String mensagemErro) {
+
+        FeedbackNotificationLogEntity log = new FeedbackNotificationLogEntity();
+        log.setId(id);
+        log.setFeedbackId(feedbackId);
+        log.setTipo(FeedbackNotificationType.EMAIL);
+        log.setStatus(status);
+        log.setDataTentativa(dataTentativa);
+        log.setMensagemErro(mensagemErro);
+        return log;
+    }
+}

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AdminFeedbackNotificationLogResourceTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AdminFeedbackNotificationLogResourceTest.java
@@ -1,0 +1,163 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.rest;
+
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.Urgencia;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackEntity;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository.PanacheFeedbackNotificationLogRepository;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository.PanacheFeedbackRepository;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.JwtSecurity;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class AdminFeedbackNotificationLogResourceTest {
+
+    @Inject
+    PanacheFeedbackRepository feedbackRepository;
+
+    @Inject
+    PanacheFeedbackNotificationLogRepository notificationLogRepository;
+
+    @BeforeEach
+    void limparBanco() {
+        QuarkusTransaction.requiringNew().run(() -> {
+            notificationLogRepository.deleteAll();
+            feedbackRepository.deleteAll();
+        });
+    }
+
+    @Test
+    @TestSecurity(user = "adminUser", roles = { "ADMIN" })
+    @JwtSecurity(claims = { @Claim(key = "groups", value = "ADMIN") })
+    void deveListarLogsDeNotificacaoDoFeedbackQuandoUsuarioForAdmin() {
+        UUID feedbackId = criarFeedbackComLogs();
+
+        given()
+                .when()
+                .get("/admin/feedbacks/{feedbackId}/notificacoes", feedbackId)
+                .then()
+                .statusCode(200)
+                .body("$", hasSize(2))
+                .body("[0].id", notNullValue())
+                .body("[0].feedbackId", equalTo(feedbackId.toString()))
+                .body("[0].tipo", equalTo("EMAIL"))
+                .body("[0].status", equalTo("FALHA"))
+                .body("[0].mensagemErro", equalTo("Timeout ao enviar e-mail"))
+                .body("[1].id", notNullValue())
+                .body("[1].feedbackId", equalTo(feedbackId.toString()))
+                .body("[1].tipo", equalTo("EMAIL"))
+                .body("[1].status", equalTo("ENVIADA"))
+                .body("[1].mensagemErro", nullValue());
+    }
+
+    @Test
+    @TestSecurity(user = "adminUser", roles = { "ADMIN" })
+    @JwtSecurity(claims = { @Claim(key = "groups", value = "ADMIN") })
+    void deveRetornarListaVaziaQuandoFeedbackNaoPossuirLogs() {
+        UUID feedbackId = criarFeedbackSemLogs();
+
+        given()
+                .when()
+                .get("/admin/feedbacks/{feedbackId}/notificacoes", feedbackId)
+                .then()
+                .statusCode(200)
+                .body("$", hasSize(0));
+    }
+
+    @Test
+    @TestSecurity(user = "alunoUser", roles = { "ALUNO" })
+    @JwtSecurity(claims = { @Claim(key = "groups", value = "ALUNO") })
+    void deveRetornarForbiddenQuandoUsuarioForAluno() {
+        UUID feedbackId = criarFeedbackComLogs();
+
+        given()
+                .when()
+                .get("/admin/feedbacks/{feedbackId}/notificacoes", feedbackId)
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "", roles = {})
+    void deveRetornarUnauthorizedQuandoUsuarioNaoEstiverAutenticado() {
+        UUID feedbackId = criarFeedbackComLogs();
+
+        given()
+                .when()
+                .get("/admin/feedbacks/{feedbackId}/notificacoes", feedbackId)
+                .then()
+                .statusCode(401);
+    }
+
+    private UUID criarFeedbackComLogs() {
+        UUID feedbackId = criarFeedbackSemLogs();
+
+        QuarkusTransaction.requiringNew().run(() -> {
+            FeedbackNotificationLogEntity logEnviado = criarLog(
+                    feedbackId,
+                    FeedbackNotificationStatus.ENVIADA,
+                    OffsetDateTime.parse("2026-05-16T10:00:00Z"),
+                    null);
+
+            FeedbackNotificationLogEntity logFalha = criarLog(
+                    feedbackId,
+                    FeedbackNotificationStatus.FALHA,
+                    OffsetDateTime.parse("2026-05-16T11:00:00Z"),
+                    "Timeout ao enviar e-mail");
+
+            notificationLogRepository.persist(logEnviado);
+            notificationLogRepository.persist(logFalha);
+        });
+
+        return feedbackId;
+    }
+
+    private UUID criarFeedbackSemLogs() {
+        UUID feedbackId = UUID.randomUUID();
+
+        QuarkusTransaction.requiringNew().run(() -> {
+            FeedbackEntity feedback = new FeedbackEntity();
+            feedback.setId(feedbackId);
+            feedback.setDescricao("Sistema com erro crítico");
+            feedback.setNota(2);
+            feedback.setUrgencia(Urgencia.ALTA);
+            feedback.setDataCriacao(OffsetDateTime.parse("2026-05-16T09:00:00Z"));
+
+            feedbackRepository.persist(feedback);
+        });
+
+        return feedbackId;
+    }
+
+    private FeedbackNotificationLogEntity criarLog(
+            UUID feedbackId,
+            FeedbackNotificationStatus status,
+            OffsetDateTime dataTentativa,
+            String mensagemErro) {
+
+        FeedbackNotificationLogEntity log = new FeedbackNotificationLogEntity();
+        log.setId(UUID.randomUUID());
+        log.setFeedbackId(feedbackId);
+        log.setTipo(FeedbackNotificationType.EMAIL);
+        log.setStatus(status);
+        log.setDataTentativa(dataTentativa);
+        log.setMensagemErro(mensagemErro);
+        return log;
+    }
+}

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AdminFeedbackNotificationLogResourceTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AdminFeedbackNotificationLogResourceTest.java
@@ -12,8 +12,10 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.jwt.Claim;
 import io.quarkus.test.security.jwt.JwtSecurity;
+import io.restassured.response.Response;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
@@ -26,6 +28,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.notNullValue;
 
 @QuarkusTest
+@DisplayName("API administrativa de logs de notificação")
 class AdminFeedbackNotificationLogResourceTest {
 
     @Inject
@@ -43,15 +46,20 @@ class AdminFeedbackNotificationLogResourceTest {
     }
 
     @Test
+    @DisplayName("Deve listar logs de notificação do feedback quando usuário for ADMIN")
     @TestSecurity(user = "adminUser", roles = { "ADMIN" })
     @JwtSecurity(claims = { @Claim(key = "groups", value = "ADMIN") })
     void deveListarLogsDeNotificacaoDoFeedbackQuandoUsuarioForAdmin() {
+        // Arrange
         UUID feedbackId = criarFeedbackComLogs();
 
-        given()
+        // Act
+        Response response = given()
                 .when()
-                .get("/admin/feedbacks/{feedbackId}/notificacoes", feedbackId)
-                .then()
+                .get("/admin/feedbacks/{feedbackId}/notificacoes", feedbackId);
+
+        // Assert
+        response.then()
                 .statusCode(200)
                 .body("$", hasSize(2))
                 .body("[0].id", notNullValue())
@@ -67,41 +75,56 @@ class AdminFeedbackNotificationLogResourceTest {
     }
 
     @Test
+    @DisplayName("Deve retornar lista vazia quando feedback não possuir logs")
     @TestSecurity(user = "adminUser", roles = { "ADMIN" })
     @JwtSecurity(claims = { @Claim(key = "groups", value = "ADMIN") })
     void deveRetornarListaVaziaQuandoFeedbackNaoPossuirLogs() {
+        // Arrange
         UUID feedbackId = criarFeedbackSemLogs();
 
-        given()
+        // Act
+        Response response = given()
                 .when()
-                .get("/admin/feedbacks/{feedbackId}/notificacoes", feedbackId)
-                .then()
+                .get("/admin/feedbacks/{feedbackId}/notificacoes", feedbackId);
+
+        // Assert
+        response.then()
                 .statusCode(200)
                 .body("$", hasSize(0));
     }
 
     @Test
+    @DisplayName("Deve retornar 403 quando usuário for ALUNO")
     @TestSecurity(user = "alunoUser", roles = { "ALUNO" })
     @JwtSecurity(claims = { @Claim(key = "groups", value = "ALUNO") })
     void deveRetornarForbiddenQuandoUsuarioForAluno() {
+        // Arrange
         UUID feedbackId = criarFeedbackComLogs();
 
-        given()
+        // Act
+        Response response = given()
                 .when()
-                .get("/admin/feedbacks/{feedbackId}/notificacoes", feedbackId)
-                .then()
+                .get("/admin/feedbacks/{feedbackId}/notificacoes", feedbackId);
+
+        // Assert
+        response.then()
                 .statusCode(403);
     }
 
     @Test
+    @DisplayName("Deve retornar 401 quando usuário não estiver autenticado")
     @TestSecurity(user = "", roles = {})
     void deveRetornarUnauthorizedQuandoUsuarioNaoEstiverAutenticado() {
+        // Arrange
         UUID feedbackId = criarFeedbackComLogs();
 
-        given()
+        // Act
+        Response response = given()
                 .when()
-                .get("/admin/feedbacks/{feedbackId}/notificacoes", feedbackId)
-                .then()
+                .get("/admin/feedbacks/{feedbackId}/notificacoes", feedbackId);
+
+        // Assert
+        response.then()
                 .statusCode(401);
     }
 

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AvaliacaoResourceTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AvaliacaoResourceTest.java
@@ -1,5 +1,6 @@
 package br.com.fiap.techchallenge.feedbackplatform.infrastructure.rest;
 
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository.PanacheFeedbackNotificationLogRepository;
 import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository.PanacheFeedbackRepository;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
@@ -23,9 +24,13 @@ class AvaliacaoResourceTest {
     @Inject
     PanacheFeedbackRepository feedbackRepository;
 
+    @Inject
+    PanacheFeedbackNotificationLogRepository notificationLogRepository;
+
     @BeforeEach
     @Transactional
     void limparBanco() {
+        notificationLogRepository.deleteAll();
         feedbackRepository.deleteAll();
     }
 

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AvaliacaoResourceTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AvaliacaoResourceTest.java
@@ -1,7 +1,11 @@
 package br.com.fiap.techchallenge.feedbackplatform.infrastructure.rest;
 
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationStatus;
+import br.com.fiap.techchallenge.feedbackplatform.domain.enums.FeedbackNotificationType;
+import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.entity.FeedbackNotificationLogEntity;
 import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository.PanacheFeedbackNotificationLogRepository;
 import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository.PanacheFeedbackRepository;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.jwt.Claim;
@@ -14,9 +18,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.UUID;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @QuarkusTest
 @TestSecurity(user = "testUser", roles = { "ALUNO" })
@@ -67,7 +76,7 @@ class AvaliacaoResourceTest {
     }
 
     @Test
-    @DisplayName("Deve criar avaliação urgente quando descrição contiver palavra crítica")
+    @DisplayName("Deve criar avaliação urgente quando a descrição contiver palavra crítica")
     void deveCriarAvaliacaoUrgenteQuandoDescricaoContiverPalavraCritica() {
         // Arrange
         String requestBody = """
@@ -96,7 +105,72 @@ class AvaliacaoResourceTest {
     }
 
     @Test
-    @DisplayName("Deve retornar 400 quando nota for maior que dez")
+    @DisplayName("Deve registrar log ENVIADA quando a avaliação for urgente")
+    void deveRegistrarLogDeNotificacaoQuandoAvaliacaoForUrgente() {
+        // Arrange
+        String requestBody = """
+                {
+                    "descricao": "A plataforma está travando durante a aula",
+                    "nota": 8
+                }
+                """;
+
+        // Act
+        Response response = given()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .when()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
+                .statusCode(201)
+                .body("urgencia", equalTo("ALTA"));
+
+        UUID feedbackId = UUID.fromString(response.jsonPath().getString("id"));
+        List<FeedbackNotificationLogEntity> logs = QuarkusTransaction.requiringNew()
+                .call(notificationLogRepository::listAll);
+
+        assertEquals(1, logs.size());
+
+        FeedbackNotificationLogEntity log = logs.getFirst();
+        assertEquals(feedbackId, log.getFeedbackId());
+        assertEquals(FeedbackNotificationType.EMAIL, log.getTipo());
+        assertEquals(FeedbackNotificationStatus.ENVIADA, log.getStatus());
+        assertNull(log.getMensagemErro());
+    }
+
+    @Test
+    @DisplayName("Não deve registrar log de notificação quando a avaliação não for urgente")
+    void deveNaoRegistrarLogQuandoAvaliacaoNaoForUrgente() {
+        // Arrange
+        String requestBody = """
+                {
+                    "descricao": "A aula foi muito boa",
+                    "nota": 9
+                }
+                """;
+
+        // Act
+        Response response = given()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .when()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
+                .statusCode(201)
+                .body("urgencia", equalTo("BAIXA"));
+
+        long totalLogs = QuarkusTransaction.requiringNew()
+                .call(notificationLogRepository::count);
+
+        assertEquals(0L, totalLogs);
+    }
+
+    @Test
+    @DisplayName("Deve retornar 400 quando a nota for maior que dez")
     void deveRetornarBadRequestQuandoNotaForMaiorQueDez() {
         // Arrange
         String requestBody = """
@@ -119,7 +193,7 @@ class AvaliacaoResourceTest {
     }
 
     @Test
-    @DisplayName("Deve retornar 400 quando nota for menor que zero")
+    @DisplayName("Deve retornar 400 quando a nota for menor que zero")
     void deveRetornarBadRequestQuandoNotaForMenorQueZero() {
         // Arrange
         String requestBody = """
@@ -142,7 +216,7 @@ class AvaliacaoResourceTest {
     }
 
     @Test
-    @DisplayName("Deve retornar 400 quando descrição estiver vazia")
+    @DisplayName("Deve retornar 400 quando a descrição estiver vazia")
     void deveRetornarBadRequestQuandoDescricaoForVazia() {
         // Arrange
         String requestBody = """
@@ -165,7 +239,7 @@ class AvaliacaoResourceTest {
     }
 
     @Test
-    @DisplayName("Deve retornar 400 quando nota não for informada")
+    @DisplayName("Deve retornar 400 quando a nota não for informada")
     void deveRetornarBadRequestQuandoNotaNaoForInformada() {
         // Arrange
         String requestBody = """
@@ -187,7 +261,7 @@ class AvaliacaoResourceTest {
     }
 
     @Test
-    @DisplayName("Deve retornar 400 quando descrição não for informada")
+    @DisplayName("Deve retornar 400 quando a descrição não for informada")
     void deveRetornarBadRequestQuandoDescricaoNaoForInformada() {
         // Arrange
         String requestBody = """
@@ -209,9 +283,9 @@ class AvaliacaoResourceTest {
     }
 
     @Test
-    @DisplayName("Deve retornar 403 quando usuário possuir role PROFESSOR")
     @TestSecurity(user = "professorUser", roles = { "PROFESSOR" })
     @JwtSecurity(claims = { @Claim(key = "groups", value = "PROFESSOR") })
+    @DisplayName("Deve retornar 403 quando usuário possuir role PROFESSOR")
     void deveRetornarForbiddenQuandoUsuarioForProfessor() {
         // Arrange
         String requestBody = """
@@ -234,9 +308,9 @@ class AvaliacaoResourceTest {
     }
 
     @Test
-    @DisplayName("Deve retornar 403 quando usuário possuir role ADMIN")
     @TestSecurity(user = "adminUser", roles = { "ADMIN" })
     @JwtSecurity(claims = { @Claim(key = "groups", value = "ADMIN") })
+    @DisplayName("Deve retornar 403 quando usuário possuir role ADMIN")
     void deveRetornarForbiddenQuandoUsuarioForAdmin() {
         // Arrange
         String requestBody = """
@@ -259,8 +333,8 @@ class AvaliacaoResourceTest {
     }
 
     @Test
-    @DisplayName("Deve retornar 401 quando usuário não estiver autenticado")
     @TestSecurity(user = "", roles = {})
+    @DisplayName("Deve retornar 401 quando usuário não estiver autenticado")
     void deveRetornarUnauthorizedQuandoNaoAutenticado() {
         // Arrange
         String requestBody = """

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AvaliacaoResourceTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AvaliacaoResourceTest.java
@@ -3,13 +3,15 @@ package br.com.fiap.techchallenge.feedbackplatform.infrastructure.rest;
 import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository.PanacheFeedbackNotificationLogRepository;
 import br.com.fiap.techchallenge.feedbackplatform.infrastructure.persistence.repository.PanacheFeedbackRepository;
 import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.http.ContentType;
-import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.jwt.Claim;
 import io.quarkus.test.security.jwt.JwtSecurity;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -19,6 +21,7 @@ import static org.hamcrest.Matchers.notNullValue;
 @QuarkusTest
 @TestSecurity(user = "testUser", roles = { "ALUNO" })
 @JwtSecurity(claims = { @Claim(key = "groups", value = "ALUNO") })
+@DisplayName("API de criação de avaliações")
 class AvaliacaoResourceTest {
 
     @Inject
@@ -35,18 +38,25 @@ class AvaliacaoResourceTest {
     }
 
     @Test
+    @DisplayName("Deve criar avaliação com sucesso quando usuário possuir role ALUNO")
     void deveCriarAvaliacaoComSucesso() {
-        given()
+        // Arrange
+        String requestBody = """
+                {
+                    "descricao": "A aula foi muito boa",
+                    "nota": 9
+                }
+                """;
+
+        // Act
+        Response response = given()
                 .contentType(ContentType.JSON)
-                .body("""
-                        {
-                                "descricao": "A aula foi muito boa",
-                                "nota": 9
-                        }
-                        """)
+                .body(requestBody)
                 .when()
-                .post("/avaliacoes")
-                .then()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
                 .statusCode(201)
                 .header("Location", notNullValue())
                 .body("id", notNullValue())
@@ -57,18 +67,25 @@ class AvaliacaoResourceTest {
     }
 
     @Test
+    @DisplayName("Deve criar avaliação urgente quando descrição contiver palavra crítica")
     void deveCriarAvaliacaoUrgenteQuandoDescricaoContiverPalavraCritica() {
-        given()
+        // Arrange
+        String requestBody = """
+                {
+                    "descricao": "A plataforma está travando durante a aula",
+                    "nota": 8
+                }
+                """;
+
+        // Act
+        Response response = given()
                 .contentType(ContentType.JSON)
-                .body("""
-                        {
-                          "descricao": "A plataforma está travando durante a aula",
-                          "nota": 8
-                        }
-                        """)
+                .body(requestBody)
                 .when()
-                .post("/avaliacoes")
-                .then()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
                 .statusCode(201)
                 .header("Location", notNullValue())
                 .body("id", notNullValue())
@@ -79,135 +96,189 @@ class AvaliacaoResourceTest {
     }
 
     @Test
+    @DisplayName("Deve retornar 400 quando nota for maior que dez")
     void deveRetornarBadRequestQuandoNotaForMaiorQueDez() {
-        given()
+        // Arrange
+        String requestBody = """
+                {
+                    "descricao": "A aula foi boa, mas o áudio estava ruim",
+                    "nota": 11
+                }
+                """;
+
+        // Act
+        Response response = given()
                 .contentType(ContentType.JSON)
-                .body("""
-                        {
-                          "descricao": "A aula foi boa, mas o áudio estava ruim",
-                          "nota": 11
-                        }
-                        """)
+                .body(requestBody)
                 .when()
-                .post("/avaliacoes")
-                .then()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
                 .statusCode(400);
     }
 
     @Test
+    @DisplayName("Deve retornar 400 quando nota for menor que zero")
     void deveRetornarBadRequestQuandoNotaForMenorQueZero() {
-        given()
+        // Arrange
+        String requestBody = """
+                {
+                    "descricao": "A aula foi boa, mas o áudio estava ruim",
+                    "nota": -1
+                }
+                """;
+
+        // Act
+        Response response = given()
                 .contentType(ContentType.JSON)
-                .body("""
-                        {
-                          "descricao": "A aula foi boa, mas o áudio estava ruim",
-                          "nota": -1
-                        }
-                        """)
+                .body(requestBody)
                 .when()
-                .post("/avaliacoes")
-                .then()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
                 .statusCode(400);
     }
 
     @Test
+    @DisplayName("Deve retornar 400 quando descrição estiver vazia")
     void deveRetornarBadRequestQuandoDescricaoForVazia() {
-        given()
+        // Arrange
+        String requestBody = """
+                {
+                    "descricao": "   ",
+                    "nota": 5
+                }
+                """;
+
+        // Act
+        Response response = given()
                 .contentType(ContentType.JSON)
-                .body("""
-                        {
-                          "descricao": "   ",
-                          "nota": 5
-                        }
-                        """)
+                .body(requestBody)
                 .when()
-                .post("/avaliacoes")
-                .then()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
                 .statusCode(400);
     }
 
     @Test
+    @DisplayName("Deve retornar 400 quando nota não for informada")
     void deveRetornarBadRequestQuandoNotaNaoForInformada() {
-        given()
+        // Arrange
+        String requestBody = """
+                {
+                    "descricao": "A aula foi boa, mas o áudio estava ruim"
+                }
+                """;
+
+        // Act
+        Response response = given()
                 .contentType(ContentType.JSON)
-                .body("""
-                        {
-                          "descricao": "A aula foi boa, mas o áudio estava ruim"
-                        }
-                        """)
+                .body(requestBody)
                 .when()
-                .post("/avaliacoes")
-                .then()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
                 .statusCode(400);
     }
 
     @Test
+    @DisplayName("Deve retornar 400 quando descrição não for informada")
     void deveRetornarBadRequestQuandoDescricaoNaoForInformada() {
-        given()
+        // Arrange
+        String requestBody = """
+                {
+                    "nota": 5
+                }
+                """;
+
+        // Act
+        Response response = given()
                 .contentType(ContentType.JSON)
-                .body("""
-                        {
-                          "nota": 5
-                        }
-                        """)
+                .body(requestBody)
                 .when()
-                .post("/avaliacoes")
-                .then()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
                 .statusCode(400);
     }
 
     @Test
+    @DisplayName("Deve retornar 403 quando usuário possuir role PROFESSOR")
     @TestSecurity(user = "professorUser", roles = { "PROFESSOR" })
     @JwtSecurity(claims = { @Claim(key = "groups", value = "PROFESSOR") })
     void deveRetornarForbiddenQuandoUsuarioForProfessor() {
-        given()
+        // Arrange
+        String requestBody = """
+                {
+                    "descricao": "Tentando avaliar como professor",
+                    "nota": 10
+                }
+                """;
+
+        // Act
+        Response response = given()
                 .contentType(ContentType.JSON)
-                .body("""
-                        {
-                          "descricao": "Tentando avaliar como professor",
-                          "nota": 10
-                        }
-                        """)
+                .body(requestBody)
                 .when()
-                .post("/avaliacoes")
-                .then()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
                 .statusCode(403);
     }
 
     @Test
+    @DisplayName("Deve retornar 403 quando usuário possuir role ADMIN")
     @TestSecurity(user = "adminUser", roles = { "ADMIN" })
     @JwtSecurity(claims = { @Claim(key = "groups", value = "ADMIN") })
     void deveRetornarForbiddenQuandoUsuarioForAdmin() {
-        given()
+        // Arrange
+        String requestBody = """
+                {
+                    "descricao": "Tentando avaliar como admin",
+                    "nota": 5
+                }
+                """;
+
+        // Act
+        Response response = given()
                 .contentType(ContentType.JSON)
-                .body("""
-                        {
-                            "descricao": "Tentando avaliar como admin",
-                            "nota": 5
-                        }
-                        """)
+                .body(requestBody)
                 .when()
-                .post("/avaliacoes")
-                .then()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
                 .statusCode(403);
     }
 
     @Test
-    @TestSecurity(user = "", roles = {}) // Remove o usuário mockado
+    @DisplayName("Deve retornar 401 quando usuário não estiver autenticado")
+    @TestSecurity(user = "", roles = {})
     void deveRetornarUnauthorizedQuandoNaoAutenticado() {
-        // Ao removermos o mock, o Quarkus vai exigir o header Authorization de verdade
-        given()
+        // Arrange
+        String requestBody = """
+                {
+                    "descricao": "Tentando avaliar sem token",
+                    "nota": 5
+                }
+                """;
+
+        // Act
+        Response response = given()
                 .contentType(ContentType.JSON)
-                .body("""
-                        {
-                                "descricao": "Tentando avaliar sem token",
-                                "nota": 5
-                        }
-                        """)
+                .body(requestBody)
                 .when()
-                .post("/avaliacoes")
-                .then()
-                // Se a chamada real for feita sem token, retorna 401
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
                 .statusCode(401);
     }
 }

--- a/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AvaliacaoResourceValidationTest.java
+++ b/src/test/java/br/com/fiap/techchallenge/feedbackplatform/infrastructure/rest/AvaliacaoResourceValidationTest.java
@@ -1,0 +1,66 @@
+package br.com.fiap.techchallenge.feedbackplatform.infrastructure.rest;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.jwt.Claim;
+import io.quarkus.test.security.jwt.JwtSecurity;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+@TestSecurity(user = "testUser", roles = { "ALUNO" })
+@JwtSecurity(claims = { @Claim(key = "groups", value = "ALUNO") })
+@DisplayName("Validações da API de criação de avaliações")
+class AvaliacaoResourceValidationTest {
+
+    @Test
+    @DisplayName("Deve retornar Bad Request quando descrição tiver menos de três caracteres")
+    void deveRetornarBadRequestQuandoDescricaoTiverMenosDeTresCaracteres() {
+        // Arrange
+        String requestBody = """
+                {
+                  "descricao": "Oi",
+                  "nota": 5
+                }
+                """;
+
+        // Act
+        Response response = given()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .when()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("Deve retornar Bad Request quando descrição tiver mais de dois mil caracteres")
+    void deveRetornarBadRequestQuandoDescricaoTiverMaisDeDoisMilCaracteres() {
+        // Arrange
+        String descricaoLonga = "a".repeat(2001);
+        String requestBody = """
+                {
+                  "descricao": "%s",
+                  "nota": 5
+                }
+                """.formatted(descricaoLonga);
+
+        // Act
+        Response response = given()
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+                .when()
+                .post("/avaliacoes");
+
+        // Assert
+        response.then()
+                .statusCode(400);
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,34 +1,17 @@
-# application.properties de test
-
-quarkus.http.root-path=api
-
-quarkus.azure.keyvault.secret.endpoint=https://localhost
+# application.properties de teste
 
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:feedback_test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1
 quarkus.datasource.username=sa
 quarkus.datasource.password=sa
 
-quarkus.hibernate-orm.schema-management.strategy=none
-quarkus.flyway.migrate-at-start=true
-
 app.email.connection-string=endpoint=https://localhost;accesskey=mock
 app.admin-emails=test@example.com
 app.email.sender-address=test@example.com
 app.email.subject=Feedback Test
 
-# Evita chamadas reais de observabilidade nos testes
+mp.jwt.verify.issuer=https://feedback-login.com.br/issuer
+mp.jwt.verify.publickey=mock-key
+
 quarkus.otel.enabled=false
 quarkus.otel.sdk.disabled=true
-
-# Evita tentativa de Service Bus real nos testes, se a extensão for adicionada depois
-# quarkus.azure.servicebus.connection-string=
-# quarkus.azure.servicebus.queue-name=
-# quarkus.azure.servicebus.namespace=
-# quarkus.azure.servicebus.devservices.enabled=false
-
-# ------------------------------------------------------------
-# Report Storage
-# ------------------------------------------------------------
-app.reports.storage.connection-string=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
-app.reports.storage.container-name=feedback-reports


### PR DESCRIPTION
Este PR complementa a cobertura de testes do az-func-feedback-core com novos cenários focados na consulta administrativa de logs, validações REST e ordenação dos registros de notificação.

Principais ajustes:
- adiciona teste unitário para ListFeedbackNotificationLogsUseCase;
- valida retorno de lista vazia quando não há logs para o feedback;
- valida falha quando feedbackId é nulo;
- adiciona testes REST para descrição com menos de 3 caracteres;
- adiciona testes REST para descrição com mais de 2000 caracteres;
- adiciona teste de ordenação dos logs por dataTentativa desc;
- garante que logs de outros feedbacks não sejam retornados na consulta por feedbackId.